### PR TITLE
use resource_info instead of resource_id on CreatePublicShare

### DIFF
--- a/cs3/publicshareprovider/v0alpha/publicshareprovider.proto
+++ b/cs3/publicshareprovider/v0alpha/publicshareprovider.proto
@@ -80,7 +80,7 @@ message CreatePublicShareRequest {
   cs3.types.Opaque opaque = 1;
   // REQUIRED.
   // The unique identifier for the shared storage resource.
-  cs3.storageproviderv0alpha.ResourceId resource_id = 2;
+  cs3.storageproviderv0alpha.ResourceInfo resource_info = 2;
   // REQUIRED.
   // The restrictions to apply to the share.
   Grant grant = 3;

--- a/docs/index.html
+++ b/docs/index.html
@@ -5332,8 +5332,8 @@ Opaque information. </p></td>
                 </tr>
               
                 <tr>
-                  <td>resource_id</td>
-                  <td><a href="#cs3.storageproviderv0alpha.ResourceId">cs3.storageproviderv0alpha.ResourceId</a></td>
+                  <td>resource_info</td>
+                  <td><a href="#cs3.storageproviderv0alpha.ResourceInfo">cs3.storageproviderv0alpha.ResourceInfo</a></td>
                   <td></td>
                   <td><p>REQUIRED.
 The unique identifier for the shared storage resource. </p></td>

--- a/proto.lock
+++ b/proto.lock
@@ -750,6 +750,12 @@
                 "id": 2,
                 "name": "ref",
                 "type": "cs3.storageproviderv0alpha.Reference"
+              },
+              {
+                "id": 3,
+                "name": "arbitrary_metadata_keys",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },
@@ -785,6 +791,12 @@
                 "id": 2,
                 "name": "ref",
                 "type": "cs3.storageproviderv0alpha.Reference"
+              },
+              {
+                "id": 3,
+                "name": "arbitrary_metadata_keys",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },
@@ -1088,6 +1100,12 @@
                 "id": 2,
                 "name": "ref",
                 "type": "cs3.storageproviderv0alpha.Reference"
+              },
+              {
+                "id": 3,
+                "name": "arbitrary_metadata_keys",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },
@@ -2125,8 +2143,8 @@
               },
               {
                 "id": 2,
-                "name": "resource_id",
-                "type": "cs3.storageproviderv0alpha.ResourceId"
+                "name": "resource_info",
+                "type": "cs3.storageproviderv0alpha.ResourceInfo"
               },
               {
                 "id": 3,
@@ -3954,6 +3972,12 @@
                 "id": 2,
                 "name": "ref",
                 "type": "Reference"
+              },
+              {
+                "id": 3,
+                "name": "arbitrary_metadata_keys",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },


### PR DESCRIPTION
Context (transcript from gitter):

>is there a reason behind the API choice for public shares vs user shares when it comes to the Create[*]ShareRequest? Where user shares requires a ResourceInfo (https://github.com/cs3org/cs3apis/blob/master/cs3/usershareprovider/v0alpha/usershareprovider.proto#L90) Public Shares requires a ResourceId (https://github.com/cs3org/cs3apis/blob/master/cs3/publicshareprovider/v0alpha/publicshareprovider.proto#L83) which enforces types that implement the public share an extra stat call to fetch the resource info (and all the instrumentation around it, i.e dependency injection)

and [a trip through git history](https://github.com/refs/cs3apis/commit/3dce4dc800e040296dd37d1d7f626ee5806c5d6b#diff-41199556adedb9d2eb022e74989713a7)

It seems this argument needs to be updated.