### PR TITLE
Add cpp to prototool list definition

### DIFF
--- a/prototool.yaml
+++ b/prototool.yaml
@@ -18,3 +18,6 @@ generate:
       type: go
       flags: plugins=grpc
       output: build/go-cs3apis
+
+    - name : cpp
+      output: build/cpp-cs3apis


### PR DESCRIPTION
I have simply added CPP to the prototool listing and tried to build the CPP definition, looks like this could be generated without issues, but I don't know if this really includes everything that is needed. Here at least a list of created files:

```
# tree build/cpp-cs3apis/
build/cpp-cs3apis/
└── cs3
    ├── appprovider
    │   └── v0alpha
    │       ├── appprovider.pb.cc
    │       └── appprovider.pb.h
    ├── appregistry
    │   └── v0alpha
    │       ├── appregistry.pb.cc
    │       ├── appregistry.pb.h
    │       ├── resources.pb.cc
    │       └── resources.pb.h
    ├── authprovider
    │   └── v0alpha
    │       ├── authprovider.pb.cc
    │       └── authprovider.pb.h
    ├── authregistry
    │   └── v0alpha
    │       ├── authregistry.pb.cc
    │       ├── authregistry.pb.h
    │       ├── resources.pb.cc
    │       └── resources.pb.h
    ├── gateway
    │   └── v0alpha
    │       ├── gateway.pb.cc
    │       └── gateway.pb.h
    ├── ocmshareprovider
    │   └── v0alpha
    │       ├── ocmshareprovider.pb.cc
    │       ├── ocmshareprovider.pb.h
    │       ├── resources.pb.cc
    │       └── resources.pb.h
    ├── preferences
    │   └── v0alpha
    │       ├── preferences.pb.cc
    │       └── preferences.pb.h
    ├── publicshareprovider
    │   └── v0alpha
    │       ├── publicshareprovider.pb.cc
    │       ├── publicshareprovider.pb.h
    │       ├── resources.pb.cc
    │       └── resources.pb.h
    ├── rpc
    │   ├── code.pb.cc
    │   ├── code.pb.h
    │   ├── status.pb.cc
    │   └── status.pb.h
    ├── storageprovider
    │   └── v0alpha
    │       ├── resources.pb.cc
    │       ├── resources.pb.h
    │       ├── storageprovider.pb.cc
    │       └── storageprovider.pb.h
    ├── storageregistry
    │   └── v0alpha
    │       ├── storageregistry.pb.cc
    │       └── storageregistry.pb.h
    ├── storagetypes
    │   ├── storagetypes.pb.cc
    │   └── storagetypes.pb.h
    ├── types
    │   ├── types.pb.cc
    │   └── types.pb.h
    ├── userprovider
    │   └── v0alpha
    │       ├── resources.pb.cc
    │       ├── resources.pb.h
    │       ├── userprovider.pb.cc
    │       └── userprovider.pb.h
    └── usershareprovider
        └── v0alpha
            ├── resources.pb.cc
            ├── resources.pb.h
            ├── usershareprovider.pb.cc
            └── usershareprovider.pb.h

28 directories, 46 files
```

@labkode @TheOneRing I'm personally not into CPP, where should these files be stored? Does it make sense to create another cs3org repo to store them, and use them within the ownCloud client? Is this missing something, I just know that @TheOneRing was hacking around with some Python script to get these definitions built.