### PR TITLE
return user on auth

### DIFF
--- a/cs3/authprovider/v0alpha/authprovider.proto
+++ b/cs3/authprovider/v0alpha/authprovider.proto
@@ -43,8 +43,6 @@ message AuthenticateRequest {
 }
 
 message AuthenticateResponse {
-  reserved 2;
-  reserved "user_id";
   cs3.rpc.Status status = 1;
-  cs3.userproviderv0alpha.User user = 3;
+  cs3.userproviderv0alpha.User user = 2;
 }

--- a/cs3/authprovider/v0alpha/authprovider.proto
+++ b/cs3/authprovider/v0alpha/authprovider.proto
@@ -30,6 +30,7 @@ option php_namespace = "CS3\\AuthProviderV0Alpha";
 
 import "cs3/rpc/status.proto";
 import "cs3/types/types.proto";
+import "cs3/userprovider/v0alpha/resources.proto";
 
 service AuthProviderService {
   rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
@@ -42,6 +43,8 @@ message AuthenticateRequest {
 }
 
 message AuthenticateResponse {
+  reserved 2;
+  reserved "user_id";
   cs3.rpc.Status status = 1;
-  cs3.types.UserId user_id = 2;
+  cs3.userproviderv0alpha.User user = 3;
 }

--- a/cs3/gateway/v0alpha/gateway.proto
+++ b/cs3/gateway/v0alpha/gateway.proto
@@ -283,8 +283,6 @@ message AuthenticateRequest {
 }
 
 message AuthenticateResponse {
-  reserved 4;
-  reserved "user_id";
   // REQUIRED.
   // The response status.
   cs3.rpc.Status status = 1;
@@ -296,7 +294,7 @@ message AuthenticateResponse {
   string token = 3;
   // REQUIRED.
   // The user.
-  cs3.userproviderv0alpha.User user = 5;
+  cs3.userproviderv0alpha.User user = 4;
 }
 
 message WhoAmIRequest {

--- a/cs3/gateway/v0alpha/gateway.proto
+++ b/cs3/gateway/v0alpha/gateway.proto
@@ -283,6 +283,8 @@ message AuthenticateRequest {
 }
 
 message AuthenticateResponse {
+  reserved 4;
+  reserved "user_id";
   // REQUIRED.
   // The response status.
   cs3.rpc.Status status = 1;
@@ -293,8 +295,8 @@ message AuthenticateResponse {
   // The access token.
   string token = 3;
   // REQUIRED.
-  // The user id.
-  cs3.types.UserId user_id = 4;
+  // The user.
+  cs3.userproviderv0alpha.User user = 5;
 }
 
 message WhoAmIRequest {

--- a/cs3/userprovider/v0alpha/resources.proto
+++ b/cs3/userprovider/v0alpha/resources.proto
@@ -31,12 +31,13 @@ option php_namespace = "CS3\\UserProviderV0Alpha";
 import "cs3/types/types.proto";
 
 message User {
+  reserved 2, 3;
+  reserved "issuer", "subject";
   cs3.types.UserId id = 1;
-  string issuer = 2;
-  string subject = 3;
   string username = 4;
   string mail = 5;
   string display_name = 6;
   repeated string groups = 7;
   cs3.types.Opaque opaque = 8;
+  bool mail_verified = 9;
 }

--- a/cs3/userprovider/v0alpha/resources.proto
+++ b/cs3/userprovider/v0alpha/resources.proto
@@ -31,13 +31,11 @@ option php_namespace = "CS3\\UserProviderV0Alpha";
 import "cs3/types/types.proto";
 
 message User {
-  reserved 2, 3;
-  reserved "issuer", "subject";
   cs3.types.UserId id = 1;
-  string username = 4;
-  string mail = 5;
-  string display_name = 6;
-  repeated string groups = 7;
-  cs3.types.Opaque opaque = 8;
-  bool mail_verified = 9;
+  string username = 2;
+  string mail = 3;
+  bool mail_verified = 4;
+  string display_name = 5;
+  repeated string groups = 6;
+  cs3.types.Opaque opaque = 7;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -2290,8 +2290,8 @@ by humans. </p></td>
                 </tr>
               
                 <tr>
-                  <td>user_id</td>
-                  <td><a href="#cs3.types.UserId">cs3.types.UserId</a></td>
+                  <td>user</td>
+                  <td><a href="#cs3.userproviderv0alpha.User">cs3.userproviderv0alpha.User</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
@@ -2677,11 +2677,11 @@ The access token. </p></td>
                 </tr>
               
                 <tr>
-                  <td>user_id</td>
-                  <td><a href="#cs3.types.UserId">cs3.types.UserId</a></td>
+                  <td>user</td>
+                  <td><a href="#cs3.userproviderv0alpha.User">cs3.userproviderv0alpha.User</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The user id. </p></td>
+The user. </p></td>
                 </tr>
               
             </tbody>
@@ -8930,20 +8930,6 @@ with different visibility levels (system-wide, user-wide, group-wide)...</p></td
                 </tr>
               
                 <tr>
-                  <td>issuer</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>subject</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
                   <td>username</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
@@ -8974,6 +8960,13 @@ with different visibility levels (system-wide, user-wide, group-wide)...</p></td
                 <tr>
                   <td>opaque</td>
                   <td><a href="#cs3.types.Opaque">cs3.types.Opaque</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>mail_verified</td>
+                  <td><a href="#bool">bool</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8944,6 +8944,13 @@ with different visibility levels (system-wide, user-wide, group-wide)...</p></td
                 </tr>
               
                 <tr>
+                  <td>mail_verified</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
                   <td>display_name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
@@ -8960,13 +8967,6 @@ with different visibility levels (system-wide, user-wide, group-wide)...</p></td
                 <tr>
                   <td>opaque</td>
                   <td><a href="#cs3.types.Opaque">cs3.types.Opaque</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>mail_verified</td>
-                  <td><a href="#bool">bool</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>

--- a/proto.lock
+++ b/proto.lock
@@ -346,8 +346,8 @@
               },
               {
                 "id": 2,
-                "name": "user_id",
-                "type": "cs3.types.UserId"
+                "name": "user",
+                "type": "cs3.userproviderv0alpha.User"
               }
             ]
           }
@@ -370,6 +370,9 @@
           },
           {
             "path": "cs3/types/types.proto"
+          },
+          {
+            "path": "cs3/userprovider/v0alpha/resources.proto"
           }
         ],
         "package": {
@@ -660,8 +663,8 @@
               },
               {
                 "id": 4,
-                "name": "user_id",
-                "type": "cs3.types.UserId"
+                "name": "user",
+                "type": "cs3.userproviderv0alpha.User"
               }
             ]
           },
@@ -1118,6 +1121,11 @@
                 "name": "ListAuthProviders",
                 "in_type": "cs3.authregistryv0alpha.ListAuthProvidersRequest",
                 "out_type": "ListAuthProvidersResponse"
+              },
+              {
+                "name": "GetHome",
+                "in_type": "cs3.storageregistryv0alpha.GetHomeRequest",
+                "out_type": "cs3.storageregistryv0alpha.GetHomeResponse"
               }
             ]
           }
@@ -1146,6 +1154,9 @@
           },
           {
             "path": "cs3/storageprovider/v0alpha/storageprovider.proto"
+          },
+          {
+            "path": "cs3/storageregistry/v0alpha/storageregistry.proto"
           },
           {
             "path": "cs3/types/types.proto"
@@ -4567,37 +4578,32 @@
               },
               {
                 "id": 2,
-                "name": "issuer",
-                "type": "string"
-              },
-              {
-                "id": 3,
-                "name": "subject",
-                "type": "string"
-              },
-              {
-                "id": 4,
                 "name": "username",
                 "type": "string"
               },
               {
-                "id": 5,
+                "id": 3,
                 "name": "mail",
                 "type": "string"
               },
               {
-                "id": 6,
+                "id": 4,
+                "name": "mail_verified",
+                "type": "bool"
+              },
+              {
+                "id": 5,
                 "name": "display_name",
                 "type": "string"
               },
               {
-                "id": 7,
+                "id": 6,
                 "name": "groups",
                 "type": "string",
                 "is_repeated": true
               },
               {
-                "id": 8,
+                "id": 7,
                 "name": "opaque",
                 "type": "cs3.types.Opaque"
               }


### PR DESCRIPTION
born out of https://github.com/cs3org/reva/pull/382 and the previous discussion in https://github.com/cs3org/reva/pull/239#issuecomment-529524824

The userid is not good enough:
- Depending on the authentication mechanism we can provide more 'claims' than just the id
- splitting auth from userlookup doubles the number of ldap lookups (one to check credentials, one to fetch user metadata ... which could be done in the same request)
- oidc does a user metadata lookup during authentication ... but has no way to forward the resolved claims to the user manager

Even the basic auth provider can return a username and a userid.

The job of the auth provider is to establish the identity of the user and return a stable identifier. But he should be allowed to provide more 'claims'.

I also cleaned up the user type to get rid of the direct `subject`and `issuer` members, which are part of the id. And I added the `mail_verified` member ....

TBH I would just add all oidc standard claims ... in a subsequent PR. For now, this would be awesome!