### PR TITLE
Adding child count information to message ResourceInfo

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -86,6 +86,9 @@ message ResourceInfo {
   // OPTIONAL.
   // Arbitrary metadata attached to a resource.
   ArbitraryMetadata arbitrary_metadata = 14;
+  // OPTIONAL
+  // Number of contained children
+  uint64 child_count = 15;
 }
 
 // CanonicalMetadata contains extra metadata


### PR DESCRIPTION
I'd like to propose an additional optional field for the ResourceInfo message:  child_count

With respect to human facing frontends (like phoenix) it could be valuable information to show the number of contained elements.

Let me know what you think of this. THX