### PR TITLE
Add recipient_mesh_provider field to CreateOCMShare

### DIFF
--- a/cs3/ocm/core/v1beta1/ocm_core_api.proto
+++ b/cs3/ocm/core/v1beta1/ocm_core_api.proto
@@ -77,7 +77,7 @@ message CreateOCMCoreShareRequest {
   // TODO: this field needs to represent either a user or group in the future, not only a user.
   cs3.identity.user.v1beta1.UserId share_with = 6;
   // REQUIRED.
-  // The protocol which is used to establish synchronisation. 
+  // The protocol which is used to establish synchronisation.
   Protocol protocol = 7;
 }
 

--- a/cs3/sharing/ocm/v1beta1/ocm_api.proto
+++ b/cs3/sharing/ocm/v1beta1/ocm_api.proto
@@ -29,6 +29,7 @@ option objc_class_prefix = "CSO";
 option php_namespace = "Cs3\\Sharing\\Ocm\\V1Beta1";
 
 import "cs3/identity/user/v1beta1/resources.proto";
+import "cs3/ocm/provider/v1beta1/resources.proto";
 import "cs3/rpc/v1beta1/status.proto";
 import "cs3/sharing/ocm/v1beta1/resources.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
@@ -91,6 +92,9 @@ message CreateOCMShareRequest {
   // REQUIRED.
   // The share grant for the share.
   ShareGrant grant = 3;
+  // REQUIRED.
+  // The details of the recipient user's mesh provider.
+  cs3.ocm.provider.v1beta1.ProviderInfo recipient_mesh_provider = 4;
 }
 
 message CreateOCMShareResponse {

--- a/docs/index.html
+++ b/docs/index.html
@@ -7371,6 +7371,14 @@ The unique identifier for the shared storage resource. </p></td>
 The share grant for the share. </p></td>
                 </tr>
               
+                <tr>
+                  <td>recipient_mesh_provider</td>
+                  <td><a href="#cs3.ocm.provider.v1beta1.ProviderInfo">cs3.ocm.provider.v1beta1.ProviderInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The details of the recipient user&#39;s mesh provider. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 


### PR DESCRIPTION
When the user calls CreateOCMShare from OCS, we need to pass the endpoint of the recipient user's provider to the GRPC method, since the package will make a call to /ocm/shares at that endpoint.