### PR TITLE
New CS3 module tx (data transfer).

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -43,8 +43,8 @@ import "cs3/sharing/link/v1beta1/link_api.proto";
 import "cs3/sharing/ocm/v1beta1/ocm_api.proto";
 import "cs3/storage/provider/v1beta1/provider_api.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
-import "cs3/types/v1beta1/types.proto";
 import "cs3/tx/v1beta1/tx_api.proto";
+import "cs3/types/v1beta1/types.proto";
 
 // Gateway API
 //
@@ -330,7 +330,6 @@ service GatewayAPI {
   rpc GetTransferStatus(cs3.tx.v1beta1.GetTransferStatusRequest) returns (cs3.tx.v1beta1.GetTransferStatusResponse);
   // Requests to cancel a transfer.
   rpc CancelTransfer(cs3.tx.v1beta1.CancelTransferRequest) returns (cs3.tx.v1beta1.CancelTransferResponse);
-
 }
 
 // CAUTION:

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -44,6 +44,7 @@ import "cs3/sharing/ocm/v1beta1/ocm_api.proto";
 import "cs3/storage/provider/v1beta1/provider_api.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
+import "cs3/tx/v1beta1/tx_api.proto";
 
 // Gateway API
 //
@@ -319,6 +320,17 @@ service GatewayAPI {
 
   // Creates a new ocm share.
   rpc CreateOCMCoreShare(cs3.ocm.core.v1beta1.CreateOCMCoreShareRequest) returns (cs3.ocm.core.v1beta1.CreateOCMCoreShareResponse);
+  // *****************************************************************/
+  // ************************** FILE TRANSFER ************************/
+  // *****************************************************************/
+
+  // Returns a response containing a TxInfo (transfer info) object.
+  rpc CreateTransfer(cs3.tx.v1beta1.CreateTransferRequest) returns (cs3.tx.v1beta1.CreateTransferResponse);
+  // Requests a transfer status.
+  rpc GetTransferStatus(cs3.tx.v1beta1.GetTransferStatusRequest) returns (cs3.tx.v1beta1.GetTransferStatusResponse);
+  // Requests to cancel a transfer.
+  rpc CancelTransfer(cs3.tx.v1beta1.CancelTransferRequest) returns (cs3.tx.v1beta1.CancelTransferResponse);
+
 }
 
 // CAUTION:

--- a/cs3/tx/v1beta1/resources.proto
+++ b/cs3/tx/v1beta1/resources.proto
@@ -45,7 +45,7 @@ message TxInfo {
     // The data transfer is accepted by the destination.
     STATUS_TRANSFER_ACCEPTED = 4;
     // The data transfer has started and not yet completed.
-    STATUS_TRANSFER_PENDING = 5;
+    STATUS_TRANSFER_IN_PROGRESS = 5;
     // The data transfer has completed.
     STATUS_TRANSFER_COMPLETE = 6;
     // The data transfer has failed.

--- a/cs3/tx/v1beta1/resources.proto
+++ b/cs3/tx/v1beta1/resources.proto
@@ -28,11 +28,16 @@ option java_package = "com.cs3.tx.v1beta1";
 option objc_class_prefix = "CTX";
 option php_namespace = "Cs3\\Tx\\V1Beta1";
 
+// TxId uniquely identifies a transfer in the transfer provider namespace.
+message TxId {
+  string opaque_id = 1;
+}
+
 // TxInfo represents information about a transfer.
 message TxInfo {
   // REQUIRED.
-  // The transfer id.
-  string id = 1;
+  // The transfer identifier.
+  TxId id = 1;
   // Status represents transfer status.
   enum Status {
     STATUS_INVALID = 0;

--- a/cs3/tx/v1beta1/resources.proto
+++ b/cs3/tx/v1beta1/resources.proto
@@ -34,6 +34,10 @@ import "cs3/types/v1beta1/types.proto";
 
 // TxId uniquely identifies a transfer in the transfer provider namespace.
 message TxId {
+  // REQUIRED.
+  // The internal transfer id used by the service implementor
+  // to uniquely identity the transfer in the internal
+  // implementation of the service.
   string opaque_id = 1;
 }
 

--- a/cs3/tx/v1beta1/resources.proto
+++ b/cs3/tx/v1beta1/resources.proto
@@ -28,6 +28,10 @@ option java_package = "com.cs3.tx.v1beta1";
 option objc_class_prefix = "CTX";
 option php_namespace = "Cs3\\Tx\\V1Beta1";
 
+import "cs3/identity/user/v1beta1/resources.proto";
+import "cs3/storage/provider/v1beta1/resources.proto";
+import "cs3/types/v1beta1/types.proto";
+
 // TxId uniquely identifies a transfer in the transfer provider namespace.
 message TxId {
   string opaque_id = 1;
@@ -38,6 +42,9 @@ message TxInfo {
   // REQUIRED.
   // The transfer identifier.
   TxId id = 1;
+  // REQUIRED.
+  // Reference of the resource to be transfered.
+  cs3.storage.provider.v1beta1.Reference ref = 2;
   // Status represents transfer status.
   enum Status {
     STATUS_INVALID = 0;
@@ -65,10 +72,19 @@ message TxInfo {
   // REQUIRED.
   // The transfer status. Eg.: STATUS_TRANSFER_FAILED.
   // Note: the description field may provide additional information on the transfer status.
-  Status status = 2;
+  Status status = 3;
+    // REQUIRED.
+  // The destination (receiver of the transfer)
+  cs3.storage.provider.v1beta1.Grantee grantee = 4;
+  // REQUIRED.
+  // Uniquely identifies a principal who initiates the transfer creation.
+  cs3.identity.user.v1beta1.UserId creator = 5;
+  // REQUIRED.
+  // Creation time of the transfer.
+  cs3.types.v1beta1.Timestamp ctime = 6;
   // OPTIONAL.
   // Information to describe the transfer status.
   // Eg. may contain information about a transfer failure.
   // Meant to be human-readable.
-  string description = 3;
+  string description = 7;
 }

--- a/cs3/tx/v1beta1/resources.proto
+++ b/cs3/tx/v1beta1/resources.proto
@@ -1,0 +1,69 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+syntax = "proto3";
+
+package cs3.tx.v1beta1;
+
+option csharp_namespace = "Cs3.Tx.V1Beta1";
+option go_package = "txv1beta1";
+option java_multiple_files = true;
+option java_outer_classname = "ResourcesProto";
+option java_package = "com.cs3.tx.v1beta1";
+option objc_class_prefix = "CTX";
+option php_namespace = "Cs3\\Tx\\V1Beta1";
+
+// TxInfo represents information about a transfer.
+message TxInfo {
+  // REQUIRED.
+  // The transfer id.
+  string id = 1;
+  // Status represents transfer status.
+  enum Status {
+    STATUS_INVALID = 0;
+    // The destination could not be found.
+    STATUS_DESTINATION_NOT_FOUND = 1;
+    // A new data transfer
+    STATUS_TRANSFER_NEW = 2;
+    // The data transfer is awaiting acceptance from the destination
+    STATUS_TRANSFER_AWAITING_ACCEPTANCE = 3;
+    // The data transfer is accepted by the destination.
+    STATUS_TRANSFER_ACCEPTED = 4;
+    // The data transfer has started and not yet completed.
+    STATUS_TRANSFER_PENDING = 5;
+    // The data transfer has completed.
+    STATUS_TRANSFER_COMPLETE = 6;
+    // The data transfer has failed.
+    STATUS_TRANSFER_FAILED = 7;
+    // The data transfer had been cancelled.
+    STATUS_TRANSFER_CANCELLED = 8;
+    // The request for cancelling the data transfer has failed.
+    STATUS_TRANSFER_CANCEL_FAILED = 9;
+    // The transfer has expired somewhere down the line.
+    STATUS_TRANSFER_EXPIRED = 10;
+  }
+  // REQUIRED.
+  // The transfer status. Eg.: STATUS_TRANSFER_FAILED.
+  // Note: the description field may provide additional information on the transfer status.
+  Status status = 2;
+  // OPTIONAL.
+  // Information to describe the transfer status.
+  // Eg. may contain information about a transfer failure.
+  // Meant to be human-readable.
+  string description = 3;
+}

--- a/cs3/tx/v1beta1/resources.proto
+++ b/cs3/tx/v1beta1/resources.proto
@@ -77,7 +77,7 @@ message TxInfo {
   // The transfer status. Eg.: STATUS_TRANSFER_FAILED.
   // Note: the description field may provide additional information on the transfer status.
   Status status = 3;
-    // REQUIRED.
+  // REQUIRED.
   // The destination (receiver of the transfer)
   cs3.storage.provider.v1beta1.Grantee grantee = 4;
   // REQUIRED.

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -65,9 +65,8 @@ message CreateTransferRequest {
   // Identifer of the resource to be transfered.
   cs3.storage.provider.v1beta1.ResourceId resource_id = 1;
   // REQUIRED.
-  // The destination reference the resource is transferred to.
-  // An email address.
-  string dest_email = 2;
+  // The destination (receiver of the transfer)
+  cs3.storage.provider.v1beta1.Grantee grantee = 2;
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 3;

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -31,6 +31,7 @@ option php_namespace = "Cs3\\Tx\\V1Beta1";
 import "cs3/rpc/v1beta1/status.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/tx/v1beta1/resources.proto";
+import "cs3/types/v1beta1/types.proto";
 
 // Tx API
 //
@@ -61,13 +62,15 @@ message CreateTransferRequest {
   // TODO: any additional fields; Opaque information ??
 
   // REQUIRED.
-  // The reference to the resource to be transfered.
-  // TODO: maybe the ResourcePermissions should be expended with a transfer permission ???
-  cs3.storage.provider.v1beta1.ResourceInfo resource_info = 1;
+  // Identifer of the resource to be transfered.
+  cs3.storage.provider.v1beta1.ResourceId resource_id = 1;
   // REQUIRED.
   // The destination reference the resource is transferred to.
   // An email address.
   string dest_email = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
 }
 
 message CreateTransferResponse {
@@ -77,12 +80,18 @@ message CreateTransferResponse {
   // REQUIRED.
   // TxInfo, includes transfer id, status, description.
   TxInfo tx_info = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
 }
 
 message GetTransferStatusRequest {
   // REQUIRED.
   // The transfer id.
   string tx_id = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
 }
 
 message GetTransferStatusResponse {
@@ -92,12 +101,18 @@ message GetTransferStatusResponse {
   // REQUIRED.
   // TxInfo, includes transfer id, status, description.
   TxInfo tx_info = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
 }
 
 message CancelTransferRequest {
   // REQUIRED.
   // The transfer id.
   string tx_id = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
 }
 
 message CancelTransferResponse {
@@ -107,4 +122,7 @@ message CancelTransferResponse {
   // REQUIRED.
   // TxInfo, includes transfer id, status, description.
   TxInfo tx_info = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
 }

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -96,7 +96,7 @@ message GetTransferStatusResponse {
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
   // REQUIRED.
-  // TxInfo, includes transfer id, status, description.
+  // TxInfo, includes ao. transfer id, status, description.
   TxInfo tx_info = 2;
   // OPTIONAL.
   // Opaque information.
@@ -117,7 +117,7 @@ message CancelTransferResponse {
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
   // REQUIRED.
-  // TxInfo, includes transfer id, status, description.
+  // TxInfo, includes ao. transfer id, status, description.
   TxInfo tx_info = 2;
   // OPTIONAL.
   // Opaque information.

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -1,0 +1,110 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+syntax = "proto3";
+
+package cs3.tx.v1beta1;
+
+option csharp_namespace = "Cs3.Tx.V1Beta1";
+option go_package = "txv1beta1";
+option java_multiple_files = true;
+option java_outer_classname = "TxApiProto";
+option java_package = "com.cs3.tx.v1beta1";
+option objc_class_prefix = "CTX";
+option php_namespace = "Cs3\\Tx\\V1Beta1";
+
+import "cs3/rpc/v1beta1/status.proto";
+import "cs3/storage/provider/v1beta1/resources.proto";
+import "cs3/tx/v1beta1/resources.proto";
+
+// Tx API
+//
+// The Tx API provides data transfer capabilities.
+//
+// The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+// NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
+// "OPTIONAL" in this document are to be interpreted as described in
+// RFC 2119.
+//
+// The following are global requirements that apply to all methods:
+// Any method MUST return CODE_OK on a succesful operation.
+// Any method MAY return NOT_IMPLEMENTED.
+// Any method MAY return INTERNAL.
+// Any method MAY return UNKNOWN.
+// Any method MAY return UNAUTHENTICATED.
+service TxAPI {
+  // Creates (requests the destination to accept) a transfer.
+  // Returns a response containing a TxInfo (transfer info) object.
+  rpc CreateTransfer(CreateTransferRequest) returns (CreateTransferResponse);
+  // Requests a transfer status.
+  rpc GetTransferStatus(GetTransferStatusRequest) returns (GetTransferStatusResponse);
+  // Requests to cancel a transfer.
+  rpc CancelTransfer(CancelTransferRequest) returns (CancelTransferResponse);
+}
+
+message CreateTransferRequest {
+  // TODO: any additional fields; Opaque information ??
+
+  // REQUIRED.
+  // The reference to the resource to be transfered.
+  // TODO: maybe the ResourcePermissions should be expended with a transfer permission ???
+  cs3.storage.provider.v1beta1.ResourceInfo resource_info = 1;
+  // REQUIRED.
+  // The destination reference the resource is transferred to.
+  // An email address.
+  string dest_email = 2;
+}
+
+message CreateTransferResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // REQUIRED.
+  // TxInfo, includes transfer id, status, description.
+  TxInfo tx_info = 2;
+}
+
+message GetTransferStatusRequest {
+  // REQUIRED.
+  // The transfer id.
+  string tx_id = 1;
+}
+
+message GetTransferStatusResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // REQUIRED.
+  // TxInfo, includes transfer id, status, description.
+  TxInfo tx_info = 2;
+}
+
+message CancelTransferRequest {
+  // REQUIRED.
+  // The transfer id.
+  string tx_id = 1;
+}
+
+message CancelTransferResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // REQUIRED.
+  // TxInfo, includes transfer id, status, description.
+  TxInfo tx_info = 2;
+}

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -59,11 +59,9 @@ service TxAPI {
 }
 
 message CreateTransferRequest {
-  // TODO: any additional fields; Opaque information ??
-
   // REQUIRED.
-  // Identifer of the resource to be transfered.
-  cs3.storage.provider.v1beta1.ResourceId resource_id = 1;
+  // Reference of the resource to be transfered.
+  cs3.storage.provider.v1beta1.Reference ref = 1;
   // REQUIRED.
   // The destination (receiver of the transfer)
   cs3.storage.provider.v1beta1.Grantee grantee = 2;

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -84,8 +84,8 @@ message CreateTransferResponse {
 
 message GetTransferStatusRequest {
   // REQUIRED.
-  // The transfer id.
-  string tx_id = 1;
+  // The transfer identifier.
+  TxId tx_id = 1;
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
@@ -105,8 +105,8 @@ message GetTransferStatusResponse {
 
 message CancelTransferRequest {
   // REQUIRED.
-  // The transfer id.
-  string tx_id = 1;
+  // The transfer identifier.
+  TxId tx_id = 1;
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;

--- a/docs/index.html
+++ b/docs/index.html
@@ -303,6 +303,64 @@
         
           
           <li>
+            <a href="#cs3%2ftx%2fv1beta1%2fresources.proto">cs3/tx/v1beta1/resources.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.TxInfo"><span class="badge">M</span>TxInfo</a>
+                </li>
+              
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.TxInfo.Status"><span class="badge">E</span>TxInfo.Status</a>
+                </li>
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#cs3%2ftx%2fv1beta1%2ftx_api.proto">cs3/tx/v1beta1/tx_api.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.CancelTransferRequest"><span class="badge">M</span>CancelTransferRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.CancelTransferResponse"><span class="badge">M</span>CancelTransferResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.CreateTransferRequest"><span class="badge">M</span>CreateTransferRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.CreateTransferResponse"><span class="badge">M</span>CreateTransferResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.GetTransferStatusRequest"><span class="badge">M</span>GetTransferStatusRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.GetTransferStatusResponse"><span class="badge">M</span>GetTransferStatusResponse</a>
+                </li>
+              
+              
+              
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.TxAPI"><span class="badge">S</span>TxAPI</a>
+                </li>
+              
+            </ul>
+          </li>
+        
+          
+          <li>
             <a href="#cs3%2ftypes%2fv1beta1%2ftypes.proto">cs3/types/v1beta1/types.proto</a>
             <ul>
               
@@ -3116,6 +3174,373 @@ https://golang.org/pkg/net/url/#URL provides a quick view of the format. </p></t
       
 
       
+    
+      
+      <div class="file-heading">
+        <h2 id="cs3/tx/v1beta1/resources.proto">cs3/tx/v1beta1/resources.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="cs3.tx.v1beta1.TxInfo">TxInfo</h3>
+        <p>TxInfo represents information about a transfer.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The transfer id. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.tx.v1beta1.TxInfo.Status">TxInfo.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The transfer status. Eg.: STATUS_TRANSFER_FAILED.
+Note: the description field may provide additional information on the transfer status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>description</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Information to describe the transfer status.
+Eg. may contain information about a transfer failure.
+Meant to be human-readable. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+        <h3 id="cs3.tx.v1beta1.TxInfo.Status">TxInfo.Status</h3>
+        <p>Status represents transfer status.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>STATUS_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_DESTINATION_NOT_FOUND</td>
+                <td>1</td>
+                <td><p>The destination could not be found.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_NEW</td>
+                <td>2</td>
+                <td><p>A new data transfer</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_AWAITING_ACCEPTANCE</td>
+                <td>3</td>
+                <td><p>The data transfer is awaiting acceptance from the destination</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_ACCEPTED</td>
+                <td>4</td>
+                <td><p>The data transfer is accepted by the destination.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_PENDING</td>
+                <td>5</td>
+                <td><p>The data transfer has started and not yet completed.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_COMPLETE</td>
+                <td>6</td>
+                <td><p>The data transfer has completed.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_FAILED</td>
+                <td>7</td>
+                <td><p>The data transfer has failed.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_CANCELLED</td>
+                <td>8</td>
+                <td><p>The data transfer had been cancelled.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_CANCEL_FAILED</td>
+                <td>9</td>
+                <td><p>The request for cancelling the data transfer has failed.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATUS_TRANSFER_EXPIRED</td>
+                <td>10</td>
+                <td><p>The transfer has expired somewhere down the line.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="cs3/tx/v1beta1/tx_api.proto">cs3/tx/v1beta1/tx_api.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="cs3.tx.v1beta1.CancelTransferRequest">CancelTransferRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>tx_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The transfer id. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.CancelTransferResponse">CancelTransferResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tx_info</td>
+                  <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+TxInfo, includes transfer id, status, description. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.CreateTransferRequest">CreateTransferRequest</h3>
+        <p>TODO: any additional fields; Opaque information ??</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>resource_info</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.ResourceInfo">cs3.storage.provider.v1beta1.ResourceInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The reference to the resource to be transfered.
+TODO: maybe the ResourcePermissions should be expended with a transfer permission ??? </p></td>
+                </tr>
+              
+                <tr>
+                  <td>dest_email</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The destination reference the resource is transferred to.
+An email address. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.CreateTransferResponse">CreateTransferResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tx_info</td>
+                  <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+TxInfo, includes transfer id, status, description. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.GetTransferStatusRequest">GetTransferStatusRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>tx_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The transfer id. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.GetTransferStatusResponse">GetTransferStatusResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tx_info</td>
+                  <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+TxInfo, includes transfer id, status, description. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+        <h3 id="cs3.tx.v1beta1.TxAPI">TxAPI</h3>
+        <p>Tx API</p><p>The Tx API provides data transfer capabilities.</p><p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL</p><p>NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and</p><p>"OPTIONAL" in this document are to be interpreted as described in</p><p>RFC 2119.</p><p>The following are global requirements that apply to all methods:</p><p>Any method MUST return CODE_OK on a succesful operation.</p><p>Any method MAY return NOT_IMPLEMENTED.</p><p>Any method MAY return INTERNAL.</p><p>Any method MAY return UNKNOWN.</p><p>Any method MAY return UNAUTHENTICATED.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Method Name</td><td>Request Type</td><td>Response Type</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>CreateTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.CreateTransferRequest">CreateTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.CreateTransferResponse">CreateTransferResponse</a></td>
+                <td><p>Creates (requests the destination to accept) a transfer.
+Returns a response containing a TxInfo (transfer info) object.</p></td>
+              </tr>
+            
+              <tr>
+                <td>GetTransferStatus</td>
+                <td><a href="#cs3.tx.v1beta1.GetTransferStatusRequest">GetTransferStatusRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.GetTransferStatusResponse">GetTransferStatusResponse</a></td>
+                <td><p>Requests a transfer status.</p></td>
+              </tr>
+            
+              <tr>
+                <td>CancelTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.CancelTransferRequest">CancelTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.CancelTransferResponse">CancelTransferResponse</a></td>
+                <td><p>Requests to cancel a transfer.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+
+        
     
       
       <div class="file-heading">

--- a/docs/index.html
+++ b/docs/index.html
@@ -307,6 +307,10 @@
             <ul>
               
                 <li>
+                  <a href="#cs3.tx.v1beta1.TxId"><span class="badge">M</span>TxId</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.tx.v1beta1.TxInfo"><span class="badge">M</span>TxInfo</a>
                 </li>
               
@@ -2700,7 +2704,32 @@ MUST return CODE_NOT_FOUND if the sync&#39;n&#39;share system provider does not 
                 <td>CreateOCMCoreShare</td>
                 <td><a href="#cs3.ocm.core.v1beta1.CreateOCMCoreShareRequest">.cs3.ocm.core.v1beta1.CreateOCMCoreShareRequest</a></td>
                 <td><a href="#cs3.ocm.core.v1beta1.CreateOCMCoreShareResponse">.cs3.ocm.core.v1beta1.CreateOCMCoreShareResponse</a></td>
-                <td><p>Creates a new ocm share.</p></td>
+                <td><p>Creates a new ocm share.
+
+*****************************************************************/
+************************** FILE TRANSFER ************************/
+*****************************************************************/</p></td>
+              </tr>
+            
+              <tr>
+                <td>CreateTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.CreateTransferRequest">.cs3.tx.v1beta1.CreateTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.CreateTransferResponse">.cs3.tx.v1beta1.CreateTransferResponse</a></td>
+                <td><p>Returns a response containing a TxInfo (transfer info) object.</p></td>
+              </tr>
+            
+              <tr>
+                <td>GetTransferStatus</td>
+                <td><a href="#cs3.tx.v1beta1.GetTransferStatusRequest">.cs3.tx.v1beta1.GetTransferStatusRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.GetTransferStatusResponse">.cs3.tx.v1beta1.GetTransferStatusResponse</a></td>
+                <td><p>Requests a transfer status.</p></td>
+              </tr>
+            
+              <tr>
+                <td>CancelTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.CancelTransferRequest">.cs3.tx.v1beta1.CancelTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.CancelTransferResponse">.cs3.tx.v1beta1.CancelTransferResponse</a></td>
+                <td><p>Requests to cancel a transfer.</p></td>
               </tr>
             
           </tbody>
@@ -3182,6 +3211,33 @@ https://golang.org/pkg/net/url/#URL provides a quick view of the format. </p></t
       <p></p>
 
       
+        <h3 id="cs3.tx.v1beta1.TxId">TxId</h3>
+        <p>TxId uniquely identifies a transfer in the transfer provider namespace.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The internal transfer id used by the service implementor
+to uniquely identity the transfer in the internal
+implementation of the service. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.tx.v1beta1.TxInfo">TxInfo</h3>
         <p>TxInfo represents information about a transfer.</p>
 
@@ -3194,10 +3250,18 @@ https://golang.org/pkg/net/url/#URL provides a quick view of the format. </p></t
               
                 <tr>
                   <td>id</td>
-                  <td><a href="#string">string</a></td>
+                  <td><a href="#cs3.tx.v1beta1.TxId">TxId</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The transfer id. </p></td>
+The transfer identifier. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+Reference of the resource to be transfered. </p></td>
                 </tr>
               
                 <tr>
@@ -3207,6 +3271,30 @@ The transfer id. </p></td>
                   <td><p>REQUIRED.
 The transfer status. Eg.: STATUS_TRANSFER_FAILED.
 Note: the description field may provide additional information on the transfer status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>grantee</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Grantee">cs3.storage.provider.v1beta1.Grantee</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The destination (receiver of the transfer) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>creator</td>
+                  <td><a href="#cs3.identity.user.v1beta1.UserId">cs3.identity.user.v1beta1.UserId</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+Uniquely identifies a principal who initiates the transfer creation. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ctime</td>
+                  <td><a href="#cs3.types.v1beta1.Timestamp">cs3.types.v1beta1.Timestamp</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+Creation time of the transfer. </p></td>
                 </tr>
               
                 <tr>
@@ -3267,7 +3355,7 @@ Meant to be human-readable. </p></td>
               </tr>
             
               <tr>
-                <td>STATUS_TRANSFER_PENDING</td>
+                <td>STATUS_TRANSFER_IN_PROGRESS</td>
                 <td>5</td>
                 <td><p>The data transfer has started and not yet completed.</p></td>
               </tr>
@@ -3329,10 +3417,18 @@ Meant to be human-readable. </p></td>
               
                 <tr>
                   <td>tx_id</td>
-                  <td><a href="#string">string</a></td>
+                  <td><a href="#cs3.tx.v1beta1.TxId">TxId</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The transfer id. </p></td>
+The transfer identifier. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
                 </tr>
               
             </tbody>
@@ -3365,7 +3461,15 @@ The response status. </p></td>
                   <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-TxInfo, includes transfer id, status, description. </p></td>
+TxInfo, includes ao. transfer id, status, description. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
                 </tr>
               
             </tbody>
@@ -3376,7 +3480,7 @@ TxInfo, includes transfer id, status, description. </p></td>
         
       
         <h3 id="cs3.tx.v1beta1.CreateTransferRequest">CreateTransferRequest</h3>
-        <p>TODO: any additional fields; Opaque information ??</p>
+        <p></p>
 
         
           <table class="field-table">
@@ -3386,21 +3490,27 @@ TxInfo, includes transfer id, status, description. </p></td>
             <tbody>
               
                 <tr>
-                  <td>resource_info</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.ResourceInfo">cs3.storage.provider.v1beta1.ResourceInfo</a></td>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The reference to the resource to be transfered.
-TODO: maybe the ResourcePermissions should be expended with a transfer permission ??? </p></td>
+Reference of the resource to be transfered. </p></td>
                 </tr>
               
                 <tr>
-                  <td>dest_email</td>
-                  <td><a href="#string">string</a></td>
+                  <td>grantee</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Grantee">cs3.storage.provider.v1beta1.Grantee</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The destination reference the resource is transferred to.
-An email address. </p></td>
+The destination (receiver of the transfer) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
                 </tr>
               
             </tbody>
@@ -3436,6 +3546,14 @@ The response status. </p></td>
 TxInfo, includes transfer id, status, description. </p></td>
                 </tr>
               
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -3455,10 +3573,18 @@ TxInfo, includes transfer id, status, description. </p></td>
               
                 <tr>
                   <td>tx_id</td>
-                  <td><a href="#string">string</a></td>
+                  <td><a href="#cs3.tx.v1beta1.TxId">TxId</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The transfer id. </p></td>
+The transfer identifier. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
                 </tr>
               
             </tbody>
@@ -3491,7 +3617,15 @@ The response status. </p></td>
                   <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-TxInfo, includes transfer id, status, description. </p></td>
+TxInfo, includes ao. transfer id, status, description. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
                 </tr>
               
             </tbody>


### PR DESCRIPTION
Some issues/questions:

- Protobuf does not like the term 'data' in a namespace, it gives an error: 

```
cs3/datatx/v1beta1/datatx_api.proto:21:1:The name "cs3.datatx.v1beta1" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
```
I now have named it 'tx' to make it compile. Maybe 'dtx' or simply ‘transfer’ is more appropriate?

- In CreateTransferRequest the resource to be transferred is of type ResourceInfo. If this type is correct then maybe the ResourcePermissions should be expended with a 'transfer' permission.

- I’m not sure if additional fields like eg. ‘opaque’ info are needed in the methods.

- I have chosen to let all 3 methods return a transfer info object (TxInfo).
- These methods also needs to added to the Gateway ?
- What are we going to do with the OCM part?
