### PR TITLE
OpenFileInAppProvider enhancements

### DIFF
--- a/cs3/app/provider/v1beta1/provider_api.proto
+++ b/cs3/app/provider/v1beta1/provider_api.proto
@@ -52,7 +52,7 @@ import "cs3/types/v1beta1/types.proto";
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
 service ProviderAPI {
-  // Returns the iframe url
+  // Returns the App provider URL
   // MUST return CODE_NOT_FOUND if the resource does not exist.
   rpc OpenFileInAppProvider(OpenFileInAppProviderRequest) returns (OpenFileInAppProviderResponse);
 }
@@ -62,19 +62,8 @@ message OpenFileInAppProviderRequest {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
-  // The resource reference. If a path is given, it will be resolved via Stat() to a ResourceId
-  // when a call to the WOPI server is to be issued.
-  storage.provider.v1beta1.Reference ref = 2;
-  // REQUIRED.
-  // The access token this application provider will use when contacting
-  // the storage provider to read and write.
-  // Service implementors MUST make sure that the access token only grants
-  // access to the requested resource.
-  // Service implementors should use a ResourceId rather than a filename to grant access, as
-  // ResourceIds MUST NOT change when a resource is renamed.
-  // The access token MUST be short-lived.
-  // TODO(labkode): investigate token derivation techniques.
-  string access_token = 3;
+  // The resourceInfo to be opened. The gateway grpc message has a ref instead.
+  storage.provider.v1beta1.ResourceInfo resource_info = 2;
   // REQUIRED.
   // View mode.
   enum ViewMode {
@@ -86,7 +75,17 @@ message OpenFileInAppProviderRequest {
     // The file can be downloaded and updated.
     VIEW_MODE_READ_WRITE = 3;
   }
-  ViewMode view_mode = 4;
+  ViewMode view_mode = 3;
+  // REQUIRED.
+  // The access token this application provider will use when contacting
+  // the storage provider to read and write.
+  // Service implementors MUST make sure that the access token only grants
+  // access to the requested resource.
+  // Service implementors should use a ResourceId rather than a filename to grant access, as
+  // ResourceIds MUST NOT change when a resource is renamed.
+  // The access token MUST be short-lived.
+  // TODO(labkode): investigate token derivation techniques.
+  string access_token = 4;
 }
 
 message OpenFileInAppProviderResponse {
@@ -98,7 +97,6 @@ message OpenFileInAppProviderResponse {
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
   // The url that user agents will render to clients.
-  // Usually the rendering happens by using HTML iframes,
-  // at least, Office 365, Collabora, OnlyOffice do like that.
+  // Usually the rendering happens by using HTML iframes or in separate browser tabs.
   string app_provider_url = 3;
 }

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -152,8 +152,8 @@ service GatewayAPI {
   // ************************ APP PROVIDER ********************/
   // *****************************************************************/
 
-  // Returns the iframe url from the WOPI server. The iframe url will let you open the document in the correct online document editor.
-  rpc OpenFileInAppProvider(cs3.app.provider.v1beta1.OpenFileInAppProviderRequest) returns (cs3.app.provider.v1beta1.OpenFileInAppProviderResponse);
+  // Returns the App provider URL, which lets the user open a file in the correct online document editor.
+  rpc OpenFileInAppProvider(OpenFileInAppProviderRequest) returns (cs3.app.provider.v1beta1.OpenFileInAppProviderResponse);
   // *****************************************************************/
   // ************************ USER SHARE PROVIDER ********************/
   // *****************************************************************/
@@ -487,4 +487,26 @@ message ListAuthProvidersResponse {
   // The list of auth types.
   // TODO(labkode): maybe add description?
   repeated string types = 3;
+}
+
+message OpenFileInAppProviderRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The resource reference. If a path is given, it will be resolved via Stat() to a ResourceInfo
+  // when a call to the WOPI server is to be issued (cf. the provider grpc message)
+  storage.provider.v1beta1.Reference ref = 2;
+  // REQUIRED.
+  // View mode.
+  enum ViewMode {
+    VIEW_MODE_INVALID = 0;
+    // The file can be opened but not downloaded.
+    VIEW_MODE_VIEW_ONLY = 1;
+    // The file can be downloaded.
+    VIEW_MODE_READ_ONLY = 2;
+    // The file can be downloaded and updated.
+    VIEW_MODE_READ_WRITE = 3;
+  }
+  ViewMode view_mode = 3;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -211,6 +211,10 @@
                 </li>
               
                 <li>
+                  <a href="#cs3.gateway.v1beta1.OpenFileInAppProviderRequest"><span class="badge">M</span>OpenFileInAppProviderRequest</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.gateway.v1beta1.PurgeRecycleRequest"><span class="badge">M</span>PurgeRecycleRequest</a>
                 </li>
               
@@ -222,6 +226,10 @@
                   <a href="#cs3.gateway.v1beta1.WhoAmIResponse"><span class="badge">M</span>WhoAmIResponse</a>
                 </li>
               
+              
+                <li>
+                  <a href="#cs3.gateway.v1beta1.OpenFileInAppProviderRequest.ViewMode"><span class="badge">E</span>OpenFileInAppProviderRequest.ViewMode</a>
+                </li>
               
               
               
@@ -1860,6 +1868,47 @@ The value is Unix Epoch timestamp in seconds. </p></td>
 
         
       
+        <h3 id="cs3.gateway.v1beta1.OpenFileInAppProviderRequest">OpenFileInAppProviderRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The resource reference. If a path is given, it will be resolved via Stat() to a ResourceInfo
+when a call to the WOPI server is to be issued (cf. the provider grpc message) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>view_mode</td>
+                  <td><a href="#cs3.gateway.v1beta1.OpenFileInAppProviderRequest.ViewMode">OpenFileInAppProviderRequest.ViewMode</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.gateway.v1beta1.PurgeRecycleRequest">PurgeRecycleRequest</h3>
         <p></p>
 
@@ -1968,6 +2017,41 @@ The user information. </p></td>
         
       
 
+      
+        <h3 id="cs3.gateway.v1beta1.OpenFileInAppProviderRequest.ViewMode">OpenFileInAppProviderRequest.ViewMode</h3>
+        <p>REQUIRED.</p><p>View mode.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>VIEW_MODE_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>VIEW_MODE_VIEW_ONLY</td>
+                <td>1</td>
+                <td><p>The file can be opened but not downloaded.</p></td>
+              </tr>
+            
+              <tr>
+                <td>VIEW_MODE_READ_ONLY</td>
+                <td>2</td>
+                <td><p>The file can be downloaded.</p></td>
+              </tr>
+            
+              <tr>
+                <td>VIEW_MODE_READ_WRITE</td>
+                <td>3</td>
+                <td><p>The file can be downloaded and updated.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
       
 
       
@@ -2173,9 +2257,9 @@ Arbitrary metadata is returned in a cs3.storage.provider.v1beta1.ResourceInfo.</
             
               <tr>
                 <td>OpenFileInAppProvider</td>
-                <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderRequest">.cs3.app.provider.v1beta1.OpenFileInAppProviderRequest</a></td>
+                <td><a href="#cs3.gateway.v1beta1.OpenFileInAppProviderRequest">OpenFileInAppProviderRequest</a></td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderResponse">.cs3.app.provider.v1beta1.OpenFileInAppProviderResponse</a></td>
-                <td><p>Returns the iframe url from the WOPI server. The iframe url will let you open the document in the correct online document editor.
+                <td><p>Returns the App provider URL, which lets the user open a file in the correct online document editor.
 
 *****************************************************************/
 ************************ USER SHARE PROVIDER ********************/
@@ -3184,12 +3268,18 @@ Opaque information. </p></td>
                 </tr>
               
                 <tr>
-                  <td>ref</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
+                  <td>resource_info</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.ResourceInfo">cs3.storage.provider.v1beta1.ResourceInfo</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The resource reference. If a path is given, it will be resolved via Stat() to a ResourceId
-when a call to the WOPI server is to be issued. </p></td>
+The resourceInfo to be opened. The gateway grpc message has a ref instead. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>view_mode</td>
+                  <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderRequest.ViewMode">OpenFileInAppProviderRequest.ViewMode</a></td>
+                  <td></td>
+                  <td><p> </p></td>
                 </tr>
               
                 <tr>
@@ -3205,13 +3295,6 @@ Service implementors should use a ResourceId rather than a filename to grant acc
 ResourceIds MUST NOT change when a resource is renamed.
 The access token MUST be short-lived.
 TODO(labkode): investigate token derivation techniques. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>view_mode</td>
-                  <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderRequest.ViewMode">OpenFileInAppProviderRequest.ViewMode</a></td>
-                  <td></td>
-                  <td><p> </p></td>
                 </tr>
               
             </tbody>
@@ -3253,8 +3336,7 @@ Opaque information. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The url that user agents will render to clients.
-Usually the rendering happens by using HTML iframes,
-at least, Office 365, Collabora, OnlyOffice do like that. </p></td>
+Usually the rendering happens by using HTML iframes or in separate browser tabs. </p></td>
                 </tr>
               
             </tbody>
@@ -3317,7 +3399,7 @@ at least, Office 365, Collabora, OnlyOffice do like that. </p></td>
                 <td>OpenFileInAppProvider</td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderRequest">OpenFileInAppProviderRequest</a></td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderResponse">OpenFileInAppProviderResponse</a></td>
-                <td><p>Returns the iframe url
+                <td><p>Returns the App provider URL
 MUST return CODE_NOT_FOUND if the resource does not exist.</p></td>
               </tr>
             

--- a/proto.lock
+++ b/proto.lock
@@ -36,18 +36,18 @@
               },
               {
                 "id": 2,
-                "name": "ref",
-                "type": "storage.provider.v1beta1.Reference"
+                "name": "resource_info",
+                "type": "storage.provider.v1beta1.ResourceInfo"
               },
               {
                 "id": 3,
-                "name": "access_token",
-                "type": "string"
+                "name": "view_mode",
+                "type": "ViewMode"
               },
               {
                 "id": 4,
-                "name": "view_mode",
-                "type": "ViewMode"
+                "name": "access_token",
+                "type": "string"
               }
             ]
           },
@@ -644,6 +644,28 @@
     {
       "protopath": "cs3:/:gateway:/:v1beta1:/:gateway_api.proto",
       "def": {
+        "enums": [
+          {
+            "name": "OpenFileInAppProviderRequest.ViewMode",
+            "enum_fields": [
+              {
+                "name": "VIEW_MODE_INVALID"
+              },
+              {
+                "name": "VIEW_MODE_VIEW_ONLY",
+                "integer": 1
+              },
+              {
+                "name": "VIEW_MODE_READ_ONLY",
+                "integer": 2
+              },
+              {
+                "name": "VIEW_MODE_READ_WRITE",
+                "integer": 3
+              }
+            ]
+          }
+        ],
         "messages": [
           {
             "name": "AuthenticateRequest",
@@ -891,6 +913,26 @@
                 "is_repeated": true
               }
             ]
+          },
+          {
+            "name": "OpenFileInAppProviderRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "ref",
+                "type": "storage.provider.v1beta1.Reference"
+              },
+              {
+                "id": 3,
+                "name": "view_mode",
+                "type": "ViewMode"
+              }
+            ]
           }
         ],
         "services": [
@@ -1006,7 +1048,7 @@
               },
               {
                 "name": "OpenFileInAppProvider",
-                "in_type": "cs3.app.provider.v1beta1.OpenFileInAppProviderRequest",
+                "in_type": "OpenFileInAppProviderRequest",
                 "out_type": "cs3.app.provider.v1beta1.OpenFileInAppProviderResponse"
               },
               {

--- a/proto.lock
+++ b/proto.lock
@@ -1145,6 +1145,11 @@
                 "out_type": "cs3.identity.user.v1beta1.GetUserResponse"
               },
               {
+                "name": "GetUserByClaim",
+                "in_type": "cs3.identity.user.v1beta1.GetUserByClaimRequest",
+                "out_type": "cs3.identity.user.v1beta1.GetUserByClaimResponse"
+              },
+              {
                 "name": "GetUserGroups",
                 "in_type": "cs3.identity.user.v1beta1.GetUserGroupsRequest",
                 "out_type": "cs3.identity.user.v1beta1.GetUserGroupsResponse"
@@ -1438,6 +1443,46 @@
             ]
           },
           {
+            "name": "GetUserByClaimRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "claim",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetUserByClaimResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "user",
+                "type": "User"
+              }
+            ]
+          },
+          {
             "name": "GetUserGroupsRequest",
             "fields": [
               {
@@ -1558,6 +1603,11 @@
                 "name": "GetUser",
                 "in_type": "GetUserRequest",
                 "out_type": "GetUserResponse"
+              },
+              {
+                "name": "GetUserByClaim",
+                "in_type": "GetUserByClaimRequest",
+                "out_type": "GetUserByClaimResponse"
               },
               {
                 "name": "GetUserGroups",
@@ -6127,6 +6177,11 @@
                 "id": 2,
                 "name": "id",
                 "type": "cs3.identity.user.v1beta1.UserId"
+              },
+              {
+                "id": 3,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
               }
             ]
           },


### PR DESCRIPTION
This PR is a breaking change to split the external (gateway) protocol from the appprovider one.

The external one does not require the user token, whereas the internal appprovider one includes now a `ResourceInfo` instead of a `Reference` and the access token.