### PR TITLE
Add name of the shared resource to OCM share

### DIFF
--- a/cs3/sharing/ocm/v1beta1/resources.proto
+++ b/cs3/sharing/ocm/v1beta1/resources.proto
@@ -43,30 +43,33 @@ message Share {
   // Unique identifier of the shared resource.
   storage.provider.v1beta1.ResourceId resource_id = 2;
   // REQUIRED.
+  // Name of the shared resource.
+  string name = 3;
+  // REQUIRED.
   // Permissions for the grantee to use
   // the resource.
-  SharePermissions permissions = 3;
+  SharePermissions permissions = 4;
   // REQUIRED.
   // The receiver of the share, like a user, group ...
-  storage.provider.v1beta1.Grantee grantee = 4;
+  storage.provider.v1beta1.Grantee grantee = 5;
   // REQUIRED.
   // Uniquely identifies the owner of the share
   // (the resource owner at the time of creating the share).
   // In case the ownership of the underlying resource changes
   // the share owner field MAY change to reflect the change of ownsership.
-  cs3.identity.user.v1beta1.UserId owner = 5;
+  cs3.identity.user.v1beta1.UserId owner = 6;
   // REQUIRED.
   // Uniquely identifies a principal who initiates the share creation.
   // A creator can create shares on behalf of the owner (because of re-sharing,
   // because belonging to special groups, ...).
   // Creator and owner often result in being the same principal.
-  cs3.identity.user.v1beta1.UserId creator = 6;
+  cs3.identity.user.v1beta1.UserId creator = 7;
   // REQUIRED.
   // Creation time of the share.
-  cs3.types.v1beta1.Timestamp ctime = 7;
+  cs3.types.v1beta1.Timestamp ctime = 8;
   // REQUIRED.
   // Last modification time of the share.
-  cs3.types.v1beta1.Timestamp mtime = 8;
+  cs3.types.v1beta1.Timestamp mtime = 9;
 }
 
 // The permissions for a share.

--- a/docs/index.html
+++ b/docs/index.html
@@ -8752,6 +8752,14 @@ Unique identifier of the shared resource. </p></td>
                 </tr>
               
                 <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+Name of the shared resource. </p></td>
+                </tr>
+              
+                <tr>
                   <td>permissions</td>
                   <td><a href="#cs3.sharing.ocm.v1beta1.SharePermissions">SharePermissions</a></td>
                   <td></td>

--- a/proto.lock
+++ b/proto.lock
@@ -4614,31 +4614,36 @@
               },
               {
                 "id": 3,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 4,
                 "name": "permissions",
                 "type": "SharePermissions"
               },
               {
-                "id": 4,
+                "id": 5,
                 "name": "grantee",
                 "type": "storage.provider.v1beta1.Grantee"
               },
               {
-                "id": 5,
+                "id": 6,
                 "name": "owner",
                 "type": "cs3.identity.user.v1beta1.UserId"
               },
               {
-                "id": 6,
+                "id": 7,
                 "name": "creator",
                 "type": "cs3.identity.user.v1beta1.UserId"
               },
               {
-                "id": 7,
+                "id": 8,
                 "name": "ctime",
                 "type": "cs3.types.v1beta1.Timestamp"
               },
               {
-                "id": 8,
+                "id": 9,
                 "name": "mtime",
                 "type": "cs3.types.v1beta1.Timestamp"
               }


### PR DESCRIPTION
Since we only store the ResourceID in OCM shares, there's no way to retrieve the resource name later. Currently we use a workaround where we append it with the share ID so that we can use it when creating references but that isn't ideal. This PR takes care of that.