### PR TITLE
Add Group API

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -288,7 +288,7 @@ service GatewayAPI {
   rpc GetGroup(cs3.identity.group.v1beta1.GetGroupRequest) returns (cs3.identity.group.v1beta1.GetGroupResponse);
   // Gets the information about a group based on a specified claim.
   rpc GetGroupByClaim(cs3.identity.group.v1beta1.GetGroupByClaimRequest) returns (cs3.identity.group.v1beta1.GetGroupByClaimResponse);
-  // Gets the groups of a group.
+  // Gets the members of a group.
   rpc GetMembers(cs3.identity.group.v1beta1.GetMembersRequest) returns (cs3.identity.group.v1beta1.GetMembersResponse);
   // Tells if the group has a certain member.
   rpc HasMember(cs3.identity.group.v1beta1.HasMemberRequest) returns (cs3.identity.group.v1beta1.HasMemberResponse);

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -34,6 +34,7 @@ import "cs3/auth/registry/v1beta1/registry_api.proto";
 import "cs3/gateway/v1beta1/resources.proto";
 import "cs3/identity/user/v1beta1/resources.proto";
 import "cs3/identity/user/v1beta1/user_api.proto";
+import "cs3/identity/group/v1beta1/group_api.proto";
 import "cs3/ocm/core/v1beta1/ocm_core_api.proto";
 import "cs3/ocm/invite/v1beta1/invite_api.proto";
 import "cs3/ocm/provider/v1beta1/provider_api.proto";
@@ -279,8 +280,21 @@ service GatewayAPI {
   // Finds users by any attribute of the user.
   // TODO(labkode): to define the filters that make more sense.
   rpc FindUsers(cs3.identity.user.v1beta1.FindUsersRequest) returns (cs3.identity.user.v1beta1.FindUsersResponse);
+  // *****************************************************************/
+  // ************************ GROUP PROVIDER **************************/
+  // *****************************************************************/
+
+  // Gets the information about a group by the group id.
+  rpc GetGroup(cs3.identity.group.v1beta1.GetGroupRequest) returns (cs3.identity.group.v1beta1.GetGroupResponse);
+  // Gets the information about a group based on a specified claim.
+  rpc GetGroupByClaim(cs3.identity.group.v1beta1.GetGroupByClaimRequest) returns (cs3.identity.group.v1beta1.GetGroupByClaimResponse);
+  // Gets the groups of a group.
+  rpc GetMembers(cs3.identity.group.v1beta1.GetMembersRequest) returns (cs3.identity.group.v1beta1.GetMembersResponse);
+  // Tells if the group has a certain member.
+  rpc HasMember(cs3.identity.group.v1beta1.HasMemberRequest) returns (cs3.identity.group.v1beta1.HasMemberResponse);
+  // TODO(labkode): to define the filters that make more sense.
   // Finds groups whose names match the specified filter.
-  rpc FindGroups(cs3.identity.user.v1beta1.FindGroupsRequest) returns (cs3.identity.user.v1beta1.FindGroupsResponse);
+  rpc FindGroups(cs3.identity.group.v1beta1.FindGroupsRequest) returns (cs3.identity.group.v1beta1.FindGroupsResponse);
   // *****************************************************************/
   // ************************ AUTH REGISTRY  **************************/
   // *****************************************************************/

--- a/cs3/identity/group/v1beta1/group_api.proto
+++ b/cs3/identity/group/v1beta1/group_api.proto
@@ -18,15 +18,15 @@
 
 syntax = "proto3";
 
-package cs3.identity.user.v1beta1;
+package cs3.identity.group.v1beta1;
 
-option csharp_namespace = "Cs3.Identity.User.V1Beta1";
-option go_package = "userv1beta1";
+option csharp_namespace = "Cs3.Identity.Group.V1Beta1";
+option go_package = "groupv1beta1";
 option java_multiple_files = true;
-option java_outer_classname = "UserApiProto";
-option java_package = "com.cs3.identity.user.v1beta1";
-option objc_class_prefix = "CIU";
-option php_namespace = "Cs3\\Identity\\User\\V1Beta1";
+option java_outer_classname = "GroupApiProto";
+option java_package = "com.cs3.identity.group.v1beta1";
+option objc_class_prefix = "CIG";
+option php_namespace = "Cs3\\Identity\\Group\\V1Beta1";
 
 import "cs3/identity/user/v1beta1/resources.proto";
 import "cs3/identity/group/v1beta1/resources.proto";
@@ -36,7 +36,7 @@ import "cs3/types/v1beta1/types.proto";
 // UserProvider API.
 //
 // The UserProvider API is responsible for creating
-// a key-value map according to user userprovider.
+// a key-value map according to group groupprovider.
 //
 // The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
 // NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
@@ -50,31 +50,30 @@ import "cs3/types/v1beta1/types.proto";
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
 
-// Provides an API for managing users.
-service UserAPI {
-  // Gets the information about a user by the user id.
-  rpc GetUser(GetUserRequest) returns (GetUserResponse);
-  // Gets the information about a user based on a specified claim.
-  rpc GetUserByClaim(GetUserByClaimRequest) returns (GetUserByClaimResponse);
-  // Gets the groups of a user.
-  rpc GetUserGroups(GetUserGroupsRequest) returns (GetUserGroupsResponse);
-  // Tells if the user is in a certain group.
-  rpc IsInGroup(IsInGroupRequest) returns (IsInGroupResponse);
-  // Finds users by any attribute of the user.
-  // TODO(labkode): to define the filters that make more sense.
-  rpc FindUsers(FindUsersRequest) returns (FindUsersResponse);
+// Provides an API for managing groups.
+service GroupAPI {
+  // Gets the information about a group by the group id.
+  rpc GetGroup(GetGroupRequest) returns (GetGroupResponse);
+  // Gets the information about a group based on a specified claim.
+  rpc GetGroupByClaim(GetGroupByClaimRequest) returns (GetGroupByClaimResponse);
+  // Gets the members of a group.
+  rpc GetMembers(GetMembersRequest) returns (GetMembersResponse);
+  // Tells if the group has certain member.
+  rpc HasMember(HasMemberRequest) returns (HasMemberResponse);
+  // Finds groups whose names match the specified filter.
+  rpc FindGroups(FindGroupsRequest) returns (FindGroupsResponse);
 }
 
-message GetUserRequest {
+message GetGroupRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
-  // The id of the user.
-  cs3.identity.user.v1beta1.UserId user_id = 2;
+  // The id of the group.
+  cs3.identity.group.v1beta1.GroupId group_id = 2;
 }
 
-message GetUserResponse {
+message GetGroupResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -82,23 +81,23 @@ message GetUserResponse {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
-  // The user information.
-  User user = 3;
+  // The group information.
+  Group group = 3;
 }
 
-message GetUserByClaimRequest {
+message GetGroupByClaimRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
-  // The claim on the basis of which users will be filtered.
+  // The claim on the basis of which groups will be filtered.
   string claim = 2;
   // REQUIRED.
-  // The value of the claim to find the specific user.
+  // The value of the claim to find the specific group.
   string value = 3;
 }
 
-message GetUserByClaimResponse {
+message GetGroupByClaimResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -106,20 +105,20 @@ message GetUserByClaimResponse {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
-  // The user information.
-  User user = 3;
+  // The group information.
+  Group group = 3;
 }
 
-message GetUserGroupsRequest {
+message GetMembersRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
-  // The id of the user.
-  cs3.identity.user.v1beta1.UserId user_id = 2;
+  // The id of the group.
+  cs3.identity.group.v1beta1.GroupId group_id = 2;
 }
 
-message GetUserGroupsResponse {
+message GetMembersResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -127,23 +126,23 @@ message GetUserGroupsResponse {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
-  // The groups for the user.
-  repeated string groups = 3;
+  // The members of the group.
+  repeated cs3.identity.user.v1beta1.UserId members = 3;
 }
 
-message IsInGroupRequest {
+message HasMemberRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
-  // The id of the user.
-  cs3.identity.user.v1beta1.UserId user_id = 2;
+  // The id of the group.
+  cs3.identity.group.v1beta1.GroupId group_id = 2;
   // REQUIRED.
-  // The id of the group to check.
-  cs3.identity.group.v1beta1.GroupId group_id = 3;
+  // The id of the user to check.
+  cs3.identity.user.v1beta1.UserId user_id = 3;
 }
 
-message IsInGroupResponse {
+message HasMemberResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -155,16 +154,16 @@ message IsInGroupResponse {
   bool ok = 3;
 }
 
-message FindUsersRequest {
+message FindGroupsRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED. TODO(labkode): create proper filters for most common searches.
+  // REQUIRED.
   // The filter to apply.
   string filter = 2;
 }
 
-message FindUsersResponse {
+message FindGroupsResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -172,7 +171,6 @@ message FindUsersResponse {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
-  // The users matching the specified filter.
-  repeated User users = 3;
+  // The groups matching the specified filter.
+  repeated Group groups = 3;
 }
-

--- a/cs3/identity/group/v1beta1/resources.proto
+++ b/cs3/identity/group/v1beta1/resources.proto
@@ -25,7 +25,7 @@ option go_package = "groupv1beta1";
 option java_multiple_files = true;
 option java_outer_classname = "ResourcesProto";
 option java_package = "com.cs3.identity.group.v1beta1";
-option objc_class_prefix = "CIU";
+option objc_class_prefix = "CIG";
 option php_namespace = "Cs3\\Identity\\Group\\V1Beta1";
 
 import "cs3/identity/user/v1beta1/resources.proto";

--- a/cs3/identity/group/v1beta1/resources.proto
+++ b/cs3/identity/group/v1beta1/resources.proto
@@ -25,7 +25,7 @@ option go_package = "groupv1beta1";
 option java_multiple_files = true;
 option java_outer_classname = "ResourcesProto";
 option java_package = "com.cs3.identity.group.v1beta1";
-option objc_class_prefix = "CIG";
+option objc_class_prefix = "CIU";
 option php_namespace = "Cs3\\Identity\\Group\\V1Beta1";
 
 import "cs3/identity/user/v1beta1/resources.proto";

--- a/cs3/identity/group/v1beta1/resources.proto
+++ b/cs3/identity/group/v1beta1/resources.proto
@@ -45,7 +45,7 @@ message GroupId {
 // Represents a group of the system.
 message Group {
   GroupId id = 1;
-  string groupname = 2;
+  string group_name = 2;
   int64 gid_number = 3;
   string mail = 4;
   bool mail_verified = 5;

--- a/cs3/identity/group/v1beta1/resources.proto
+++ b/cs3/identity/group/v1beta1/resources.proto
@@ -18,38 +18,38 @@
 
 syntax = "proto3";
 
-package cs3.identity.user.v1beta1;
+package cs3.identity.group.v1beta1;
 
-option csharp_namespace = "Cs3.Identity.User.V1Beta1";
-option go_package = "userv1beta1";
+option csharp_namespace = "Cs3.Identity.Group.V1Beta1";
+option go_package = "groupv1beta1";
 option java_multiple_files = true;
 option java_outer_classname = "ResourcesProto";
-option java_package = "com.cs3.identity.user.v1beta1";
+option java_package = "com.cs3.identity.group.v1beta1";
 option objc_class_prefix = "CIU";
-option php_namespace = "Cs3\\Identity\\User\\V1Beta1";
+option php_namespace = "Cs3\\Identity\\Group\\V1Beta1";
 
+import "cs3/identity/user/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 
-// A UserId represents a user.
-message UserId {
+// A GroupId represents a group.
+message GroupId {
   // REQUIRED.
-  // The identity provider for the user.
+  // The identity provider for the group.
   string idp = 1;
   // REQUIRED.
-  // the unique identifier for the user in the scope of
+  // the unique identifier for the group in the scope of
   // the identity provider.
   string opaque_id = 2;
 }
 
-// Represents a user of the system.
-message User {
-  UserId id = 1;
-  string username = 2;
-  int64 uid_number = 3;
-  int64 gid_number = 4;
-  string mail = 5;
-  bool mail_verified = 6;
-  string display_name = 7;
-  repeated string groups = 8;
-  cs3.types.v1beta1.Opaque opaque = 9;
+// Represents a group of the system.
+message Group {
+  GroupId id = 1;
+  string groupname = 2;
+  int64 gid_number = 3;
+  string mail = 4;
+  bool mail_verified = 5;
+  string display_name = 6;
+  repeated cs3.identity.user.v1beta1.UserId members = 7;
+  cs3.types.v1beta1.Opaque opaque = 8;
 }

--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -25,7 +25,7 @@ option go_package = "userv1beta1";
 option java_multiple_files = true;
 option java_outer_classname = "ResourcesProto";
 option java_package = "com.cs3.identity.user.v1beta1";
-option objc_class_prefix = "CIG";
+option objc_class_prefix = "CIU";
 option php_namespace = "Cs3\\Identity\\User\\V1Beta1";
 
 import "cs3/types/v1beta1/types.proto";

--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -25,7 +25,7 @@ option go_package = "userv1beta1";
 option java_multiple_files = true;
 option java_outer_classname = "ResourcesProto";
 option java_package = "com.cs3.identity.user.v1beta1";
-option objc_class_prefix = "CIU";
+option objc_class_prefix = "CIG";
 option php_namespace = "Cs3\\Identity\\User\\V1Beta1";
 
 import "cs3/types/v1beta1/types.proto";

--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -45,11 +45,11 @@ message UserId {
 message User {
   UserId id = 1;
   string username = 2;
-  int64 uid_number = 3;
-  int64 gid_number = 4;
-  string mail = 5;
-  bool mail_verified = 6;
-  string display_name = 7;
-  repeated string groups = 8;
-  cs3.types.v1beta1.Opaque opaque = 9;
+  string mail = 3;
+  bool mail_verified = 4;
+  string display_name = 5;
+  repeated string groups = 6;
+  cs3.types.v1beta1.Opaque opaque = 7;
+  int64 uid_number = 8;
+  int64 gid_number = 9;
 }

--- a/cs3/identity/user/v1beta1/user_api.proto
+++ b/cs3/identity/user/v1beta1/user_api.proto
@@ -25,7 +25,7 @@ option go_package = "userv1beta1";
 option java_multiple_files = true;
 option java_outer_classname = "UserApiProto";
 option java_package = "com.cs3.identity.user.v1beta1";
-option objc_class_prefix = "CIU";
+option objc_class_prefix = "CIG";
 option php_namespace = "Cs3\\Identity\\User\\V1Beta1";
 
 import "cs3/identity/user/v1beta1/resources.proto";

--- a/cs3/identity/user/v1beta1/user_api.proto
+++ b/cs3/identity/user/v1beta1/user_api.proto
@@ -25,7 +25,7 @@ option go_package = "userv1beta1";
 option java_multiple_files = true;
 option java_outer_classname = "UserApiProto";
 option java_package = "com.cs3.identity.user.v1beta1";
-option objc_class_prefix = "CIG";
+option objc_class_prefix = "CIU";
 option php_namespace = "Cs3\\Identity\\User\\V1Beta1";
 
 import "cs3/identity/user/v1beta1/resources.proto";

--- a/proto.lock
+++ b/proto.lock
@@ -1193,9 +1193,29 @@
                 "out_type": "cs3.identity.user.v1beta1.FindUsersResponse"
               },
               {
+                "name": "GetGroup",
+                "in_type": "cs3.identity.group.v1beta1.GetGroupRequest",
+                "out_type": "cs3.identity.group.v1beta1.GetGroupResponse"
+              },
+              {
+                "name": "GetGroupByClaim",
+                "in_type": "cs3.identity.group.v1beta1.GetGroupByClaimRequest",
+                "out_type": "cs3.identity.group.v1beta1.GetGroupByClaimResponse"
+              },
+              {
+                "name": "GetMembers",
+                "in_type": "cs3.identity.group.v1beta1.GetMembersRequest",
+                "out_type": "cs3.identity.group.v1beta1.GetMembersResponse"
+              },
+              {
+                "name": "HasMember",
+                "in_type": "cs3.identity.group.v1beta1.HasMemberRequest",
+                "out_type": "cs3.identity.group.v1beta1.HasMemberResponse"
+              },
+              {
                 "name": "FindGroups",
-                "in_type": "cs3.identity.user.v1beta1.FindGroupsRequest",
-                "out_type": "cs3.identity.user.v1beta1.FindGroupsResponse"
+                "in_type": "cs3.identity.group.v1beta1.FindGroupsRequest",
+                "out_type": "cs3.identity.group.v1beta1.FindGroupsResponse"
               },
               {
                 "name": "ListAuthProviders",
@@ -1283,6 +1303,9 @@
           },
           {
             "path": "cs3/identity/user/v1beta1/user_api.proto"
+          },
+          {
+            "path": "cs3/identity/group/v1beta1/group_api.proto"
           },
           {
             "path": "cs3/ocm/core/v1beta1/ocm_core_api.proto"
@@ -1464,6 +1487,388 @@
       }
     },
     {
+      "protopath": "cs3:/:identity:/:group:/:v1beta1:/:group_api.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "GetGroupRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              }
+            ]
+          },
+          {
+            "name": "GetGroupResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "group",
+                "type": "Group"
+              }
+            ]
+          },
+          {
+            "name": "GetGroupByClaimRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "claim",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetGroupByClaimResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "group",
+                "type": "Group"
+              }
+            ]
+          },
+          {
+            "name": "GetMembersRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              }
+            ]
+          },
+          {
+            "name": "GetMembersResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "members",
+                "type": "cs3.identity.user.v1beta1.UserId",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "HasMemberRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              },
+              {
+                "id": 3,
+                "name": "user_id",
+                "type": "cs3.identity.user.v1beta1.UserId"
+              }
+            ]
+          },
+          {
+            "name": "HasMemberResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "ok",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "FindGroupsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "filter",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "FindGroupsResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "groups",
+                "type": "Group",
+                "is_repeated": true
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "GroupAPI",
+            "rpcs": [
+              {
+                "name": "GetGroup",
+                "in_type": "GetGroupRequest",
+                "out_type": "GetGroupResponse"
+              },
+              {
+                "name": "GetGroupByClaim",
+                "in_type": "GetGroupByClaimRequest",
+                "out_type": "GetGroupByClaimResponse"
+              },
+              {
+                "name": "GetMembers",
+                "in_type": "GetMembersRequest",
+                "out_type": "GetMembersResponse"
+              },
+              {
+                "name": "HasMember",
+                "in_type": "HasMemberRequest",
+                "out_type": "HasMemberResponse"
+              },
+              {
+                "name": "FindGroups",
+                "in_type": "FindGroupsRequest",
+                "out_type": "FindGroupsResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "cs3/identity/user/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/identity/group/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/rpc/v1beta1/status.proto"
+          },
+          {
+            "path": "cs3/types/v1beta1/types.proto"
+          }
+        ],
+        "package": {
+          "name": "cs3.identity.group.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Identity.Group.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "groupv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "GroupApiProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.identity.group.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CIG"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Identity\\\\Group\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "cs3:/:identity:/:group:/:v1beta1:/:resources.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "GroupId",
+            "fields": [
+              {
+                "id": 1,
+                "name": "idp",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "opaque_id",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Group",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "GroupId"
+              },
+              {
+                "id": 2,
+                "name": "group_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "gid_number",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "mail",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "mail_verified",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "display_name",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "members",
+                "type": "cs3.identity.user.v1beta1.UserId",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "cs3/identity/user/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/types/v1beta1/types.proto"
+          }
+        ],
+        "package": {
+          "name": "cs3.identity.group.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Identity.Group.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "groupv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ResourcesProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.identity.group.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CIU"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Identity\\\\Group\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
       "protopath": "cs3:/:identity:/:user:/:v1beta1:/:resources.proto",
       "def": {
         "messages": [
@@ -1520,6 +1925,16 @@
                 "id": 7,
                 "name": "opaque",
                 "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 8,
+                "name": "uid_number",
+                "type": "int64"
+              },
+              {
+                "id": 9,
+                "name": "gid_number",
+                "type": "int64"
               }
             ]
           }
@@ -1694,8 +2109,8 @@
               },
               {
                 "id": 3,
-                "name": "group",
-                "type": "string"
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
               }
             ]
           },
@@ -1754,42 +2169,6 @@
                 "is_repeated": true
               }
             ]
-          },
-          {
-            "name": "FindGroupsRequest",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "filter",
-                "type": "string"
-              }
-            ]
-          },
-          {
-            "name": "FindGroupsResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "status",
-                "type": "cs3.rpc.v1beta1.Status"
-              },
-              {
-                "id": 2,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 3,
-                "name": "groups",
-                "type": "string",
-                "is_repeated": true
-              }
-            ]
           }
         ],
         "services": [
@@ -1820,11 +2199,6 @@
                 "name": "FindUsers",
                 "in_type": "FindUsersRequest",
                 "out_type": "FindUsersResponse"
-              },
-              {
-                "name": "FindGroups",
-                "in_type": "FindGroupsRequest",
-                "out_type": "FindGroupsResponse"
               }
             ]
           }
@@ -1832,6 +2206,9 @@
         "imports": [
           {
             "path": "cs3/identity/user/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/identity/group/v1beta1/resources.proto"
           },
           {
             "path": "cs3/rpc/v1beta1/status.proto"

--- a/proto.lock
+++ b/proto.lock
@@ -1859,7 +1859,7 @@
           },
           {
             "name": "objc_class_prefix",
-            "value": "CIU"
+            "value": "CIG"
           },
           {
             "name": "php_namespace",
@@ -1970,7 +1970,7 @@
           },
           {
             "name": "objc_class_prefix",
-            "value": "CIU"
+            "value": "CIG"
           },
           {
             "name": "php_namespace",
@@ -2243,7 +2243,7 @@
           },
           {
             "name": "objc_class_prefix",
-            "value": "CIU"
+            "value": "CIG"
           },
           {
             "name": "php_namespace",

--- a/proto.lock
+++ b/proto.lock
@@ -1859,7 +1859,7 @@
           },
           {
             "name": "objc_class_prefix",
-            "value": "CIG"
+            "value": "CIU"
           },
           {
             "name": "php_namespace",
@@ -1970,7 +1970,7 @@
           },
           {
             "name": "objc_class_prefix",
-            "value": "CIG"
+            "value": "CIU"
           },
           {
             "name": "php_namespace",
@@ -2243,7 +2243,7 @@
           },
           {
             "name": "objc_class_prefix",
-            "value": "CIG"
+            "value": "CIU"
           },
           {
             "name": "php_namespace",

--- a/proto.lock
+++ b/proto.lock
@@ -1859,7 +1859,7 @@
           },
           {
             "name": "objc_class_prefix",
-            "value": "CIU"
+            "value": "CIG"
           },
           {
             "name": "php_namespace",


### PR DESCRIPTION
Signed-off-by: Jörn Friedrich Dreyer <jfd@butonic.de>

> This PR adds a readonly groups api to CS3.
Similar to users groups have a persistent, non reassignable, stable, unique identifier which we call id
In addition to that the CS3 API knows other identifiers like a name, an email and numeric identifiers (which we used to carry as opaque payload).

I did not care to preserve backwards compatability and reused old ids, which is why there are build failures for protobuf.

Let me know if we can go forward with this or if the API is considered staple and we need to keep backwards compatabililty.