### PR TITLE
Make the grantee ID either that of a user or a group

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -28,6 +28,7 @@ option java_package = "com.cs3.storage.provider.v1beta1";
 option objc_class_prefix = "CSP";
 option php_namespace = "Cs3\\Storage\\Provider\\V1Beta1";
 
+import "cs3/identity/group/v1beta1/resources.proto";
 import "cs3/identity/user/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 
@@ -255,12 +256,18 @@ message Grantee {
   // REQUIRED.
   // The type of the grantee.
   GranteeType type = 1;
+  // REQUIRED.
   // The unique id for the grantee.
-  // For example, a group name, user name or uuid.
-  cs3.identity.user.v1beta1.UserId id = 2;
+  // One of the ids MUST be specified.
+  oneof id {
+    // The user id.
+    cs3.identity.user.v1beta1.UserId user_id = 3;
+    // The group id.
+    cs3.identity.group.v1beta1.GroupId group_id = 4;
+  }
   // OPTIONAL.
   // Opaque information such as UID or GID.
-  cs3.types.v1beta1.Opaque opaque = 3;
+  cs3.types.v1beta1.Opaque opaque = 5;
 }
 
 // The type of the grantee.

--- a/docs/index.html
+++ b/docs/index.html
@@ -12806,11 +12806,17 @@ The type of the grantee. </p></td>
                 </tr>
               
                 <tr>
-                  <td>id</td>
+                  <td>user_id</td>
                   <td><a href="#cs3.identity.user.v1beta1.UserId">cs3.identity.user.v1beta1.UserId</a></td>
                   <td></td>
-                  <td><p>The unique id for the grantee.
-For example, a group name, user name or uuid. </p></td>
+                  <td><p>The user id. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>group_id</td>
+                  <td><a href="#cs3.identity.group.v1beta1.GroupId">cs3.identity.group.v1beta1.GroupId</a></td>
+                  <td></td>
+                  <td><p>The group id. </p></td>
                 </tr>
               
                 <tr>

--- a/proto.lock
+++ b/proto.lock
@@ -6731,12 +6731,17 @@
                 "type": "GranteeType"
               },
               {
-                "id": 2,
-                "name": "id",
+                "id": 3,
+                "name": "user_id",
                 "type": "cs3.identity.user.v1beta1.UserId"
               },
               {
-                "id": 3,
+                "id": 4,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              },
+              {
+                "id": 5,
                 "name": "opaque",
                 "type": "cs3.types.v1beta1.Opaque"
               }
@@ -6860,6 +6865,9 @@
           }
         ],
         "imports": [
+          {
+            "path": "cs3/identity/group/v1beta1/resources.proto"
+          },
           {
             "path": "cs3/identity/user/v1beta1/resources.proto"
           },


### PR DESCRIPTION
To enable group sharing, the grantee ID can be either a user ID or a group ID