### PR TITLE
Add GetAcceptedUsers to Invite api

### DIFF
--- a/cs3/ocm/invite/v1beta1/invite_api.proto
+++ b/cs3/ocm/invite/v1beta1/invite_api.proto
@@ -59,6 +59,8 @@ service InviteAPI {
   rpc AcceptInvite(AcceptInviteRequest) returns (AcceptInviteResponse);
   // Retrieves details about a remote user who has accepted an invite to share.
   rpc GetRemoteUser(GetRemoteUserRequest) returns (GetRemoteUserResponse);
+  // Retrieves a list of users that accepted a certain invite token
+  rpc GetAcceptedUsers(GetAcceptedUsersRequest) returns (GetAcceptedUsersResponse);
 }
 
 message GenerateInviteTokenRequest {
@@ -140,4 +142,25 @@ message GetRemoteUserResponse {
   // REQUIRED.
   // The user information.
   cs3.identity.user.v1beta1.User remote_user = 3;
+}
+
+message GetAcceptedUsersRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The token name to search accepted users for.
+  string token_name = 2;
+}
+
+message GetAcceptedUsersResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The users that accepted the token with the given name.
+  repeated cs3.identity.user.v1beta1.User accepted_users = 3;
 }

--- a/cs3/ocm/invite/v1beta1/resources.proto
+++ b/cs3/ocm/invite/v1beta1/resources.proto
@@ -44,4 +44,7 @@ message InviteToken {
   // OPTIONAL.
   // The time when the token will expire.
   cs3.types.v1beta1.Timestamp expiration = 3;
+  // REQUIRED.
+  // User-defined token name for token identification.
+  string name = 4;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -765,6 +765,14 @@
                 <li>
                   <a href="#cs3.ocm.invite.v1beta1.GetRemoteUserResponse"><span class="badge">M</span>GetRemoteUserResponse</a>
                 </li>
+
+                <li>
+                    <a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest"><span class="badge">M</span>GetAcceptedUsersRequest</a>
+                </li>
+
+                <li>
+                    <a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse"><span class="badge">M</span>GetAcceptedUsersResponse</a>
+                </li>
               
               
               
@@ -2832,11 +2840,14 @@ When a user has access to multiple storage providers, one of them is the home.
                 <td>GetRemoteUser</td>
                 <td><a href="#cs3.ocm.invite.v1beta1.GetRemoteUserRequest">.cs3.ocm.invite.v1beta1.GetRemoteUserRequest</a></td>
                 <td><a href="#cs3.ocm.invite.v1beta1.GetRemoteUserResponse">.cs3.ocm.invite.v1beta1.GetRemoteUserResponse</a></td>
-                <td><p>Retrieves details about a remote user who has accepted an invite to share.
+                <td><p>Retrieves details about a remote user who has accepted an invite to share.</p></td>
+              </tr>
 
-*****************************************************************/
-******************** OCM PROVIDER AUTHORIZER ********************/
-*****************************************************************/</p></td>
+              <tr>
+                <td>GetAcceptedUsers</td>
+                <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">.cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest</a></td>
+                <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">.cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse</a></td>
+                <td><p>Retrieves a list of users that accepted a certain invite token.</p></td>
               </tr>
             
               <tr>
@@ -6432,17 +6443,86 @@ The user information. </p></td>
             </tbody>
           </table>
 
-          
 
-        
-      
 
-      
 
-      
 
-      
-        <h3 id="cs3.ocm.invite.v1beta1.InviteAPI">InviteAPI</h3>
+
+    <h3 id="cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">GetAcceptedUsersRequest</h3>
+    <p></p>
+
+
+    <table class="field-table">
+        <thead>
+        <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+        </thead>
+        <tbody>
+
+        <tr>
+            <td>opaque</td>
+            <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+            <td></td>
+            <td><p>OPTIONAL.
+                Opaque information. </p></td>
+        </tr>
+
+        <tr>
+            <td>token_name</td>
+            <td><a href="#string">string</a></td>
+            <td></td>
+            <td><p>REQUIRED.
+                The token name to search accepted users for. </p></td>
+        </tr>
+
+        </tbody>
+    </table>
+
+
+
+
+
+    <h3 id="cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">GetAcceptedUsersResponse</h3>
+    <p></p>
+
+
+    <table class="field-table">
+        <thead>
+        <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+        </thead>
+        <tbody>
+
+        <tr>
+            <td>status</td>
+            <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+            <td></td>
+            <td><p>REQUIRED.
+                The response status. </p></td>
+        </tr>
+
+        <tr>
+            <td>opaque</td>
+            <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+            <td></td>
+            <td><p>OPTIONAL.
+                Opaque information. </p></td>
+        </tr>
+
+        <tr>
+            <td>accepted_users</td>
+            <td><a href="#cs3.identity.user.v1beta1.User">cs3.identity.user.v1beta1.User</a></td>
+            <td>repeated</td>
+            <td><p>REQUIRED.
+                The users that accepted the token with the given name. </p></td>
+        </tr>
+
+        </tbody>
+    </table>
+
+
+
+
+
+    <h3 id="cs3.ocm.invite.v1beta1.InviteAPI">InviteAPI</h3>
         <p>Invite API</p><p>The Invite API is meant to invite users and groups belonging to other</p><p>sync'n'share systems, so that collaboration of resources can be enabled.</p><p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL</p><p>NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and</p><p>"OPTIONAL" in this document are to be interpreted as described in</p><p>RFC 2119.</p><p>The following are global requirements that apply to all methods:</p><p>Any method MUST return CODE_OK on a succesful operation.</p><p>Any method MAY return NOT_IMPLEMENTED.</p><p>Any method MAY return INTERNAL.</p><p>Any method MAY return UNKNOWN.</p><p>Any method MAY return UNAUTHENTICATED.</p>
         <table class="enum-table">
           <thead>
@@ -6477,7 +6557,13 @@ The user information. </p></td>
                 <td><a href="#cs3.ocm.invite.v1beta1.GetRemoteUserResponse">GetRemoteUserResponse</a></td>
                 <td><p>Retrieves details about a remote user who has accepted an invite to share.</p></td>
               </tr>
-            
+
+              <tr>
+                  <td>GetAcceptedUsers</td>
+                  <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">GetAcceptedUsersRequest</a></td>
+                  <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">GetAcceptedUsersResponse</a></td>
+                  <td><p>Retrieves a list of users that accepted a certain invite token.</p></td>
+              </tr>
           </tbody>
         </table>
 
@@ -6523,7 +6609,14 @@ The user who created the token. </p></td>
                   <td><p>OPTIONAL.
 The time when the token will expire. </p></td>
                 </tr>
-              
+
+                <tr>
+                    <td>name</td>
+                    <td><a href="#string">string</a></td>
+                    <td></td>
+                    <td><p>REQUIRED.
+User-defined token name for token identification. </p></td>
+                </tr>
             </tbody>
           </table>
 


### PR DESCRIPTION
This PR adds a new rpc endpoint to fetch all users that accepted a certain InviteToken with a certain token name/label.

This requires that additional `name` field is also added by this PR to the `InviteToken` resource.
This field holds a user-definable token name, so that the user can later query for all users that accepted the token with this name.

Related [reva#1484](https://github.com/cs3org/reva/issues/1484)