### PR TITLE
Clarify that the path has a leading slash in RecycleItem

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -310,6 +310,7 @@ message RecycleItem {
   string key = 3;
   // REQUIRED.
   // The original path of the deleted resource.
+  // MUST start with the slash character (/).
   string path = 4;
   // OPTIONAL.
   // The size of the deleted resource.


### PR DESCRIPTION
The `RecycleItem` path should have a leading slash like other paths as well, but it was currently not specified to have it.