### PR TITLE
Share type added to specify Share purpose.

### DIFF
--- a/cs3/ocm/invite/v1beta1/invite_api.proto
+++ b/cs3/ocm/invite/v1beta1/invite_api.proto
@@ -59,7 +59,7 @@ service InviteAPI {
   rpc AcceptInvite(AcceptInviteRequest) returns (AcceptInviteResponse);
   // Retrieves details about a remote user who has accepted an invite to share.
   rpc GetRemoteUser(GetRemoteUserRequest) returns (GetRemoteUserResponse);
-  // Retrieves a list of users that accepted a certain invite token
+  // Retrieves a list of users that accepted a certain invite token.
   rpc GetAcceptedUsers(GetAcceptedUsersRequest) returns (GetAcceptedUsersResponse);
 }
 

--- a/cs3/sharing/ocm/v1beta1/resources.proto
+++ b/cs3/sharing/ocm/v1beta1/resources.proto
@@ -72,10 +72,11 @@ message Share {
   cs3.types.v1beta1.Timestamp mtime = 9;
   // Share type defines purpose.
   enum ShareType {
+    SHARE_TYPE_INVALID = 0;
     // A regular file or folder share (this is the default share type).
-    SHARE = 0;
+    SHARE_TYPE_REGULAR = 1;
     // A file or folder transfer.
-    TRANSFER = 1;
+    SHARE_TYPE_TRANSFER = 2;
   }
   // Specifies the type of the share so  
   // the service implementor can act accordingly.

--- a/cs3/sharing/ocm/v1beta1/resources.proto
+++ b/cs3/sharing/ocm/v1beta1/resources.proto
@@ -70,7 +70,7 @@ message Share {
   // REQUIRED.
   // Last modification time of the share.
   cs3.types.v1beta1.Timestamp mtime = 9;
-  // Share type defines purpose.
+  // Defines the type of share based on its origin.
   enum ShareType {
     SHARE_TYPE_INVALID = 0;
     // A regular file or folder share.
@@ -78,8 +78,7 @@ message Share {
     // A file or folder transfer.
     SHARE_TYPE_TRANSFER = 2;
   }
-  // Specifies the type of the share so
-  // the service implementor can act accordingly.
+  // Specifies the type of the share.
   ShareType share_type = 10;
 }
 

--- a/cs3/sharing/ocm/v1beta1/resources.proto
+++ b/cs3/sharing/ocm/v1beta1/resources.proto
@@ -73,12 +73,12 @@ message Share {
   // Share type defines purpose.
   enum ShareType {
     SHARE_TYPE_INVALID = 0;
-    // A regular file or folder share (this is the default share type).
+    // A regular file or folder share.
     SHARE_TYPE_REGULAR = 1;
     // A file or folder transfer.
     SHARE_TYPE_TRANSFER = 2;
   }
-  // Specifies the type of the share so  
+  // Specifies the type of the share so
   // the service implementor can act accordingly.
   ShareType share_type = 10;
 }

--- a/cs3/sharing/ocm/v1beta1/resources.proto
+++ b/cs3/sharing/ocm/v1beta1/resources.proto
@@ -70,6 +70,16 @@ message Share {
   // REQUIRED.
   // Last modification time of the share.
   cs3.types.v1beta1.Timestamp mtime = 9;
+  // Share type defines purpose.
+  enum ShareType {
+    // A regular file or folder share (this is the default share type).
+    SHARE = 0;
+    // A file or folder transfer.
+    TRANSFER = 1;
+  }
+  // Specifies the type of the share so  
+  // the service implementor can act accordingly.
+  ShareType share_type = 10;
 }
 
 // The permissions for a share.

--- a/docs/index.html
+++ b/docs/index.html
@@ -759,19 +759,19 @@
                 </li>
               
                 <li>
+                  <a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest"><span class="badge">M</span>GetAcceptedUsersRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse"><span class="badge">M</span>GetAcceptedUsersResponse</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.ocm.invite.v1beta1.GetRemoteUserRequest"><span class="badge">M</span>GetRemoteUserRequest</a>
                 </li>
               
                 <li>
                   <a href="#cs3.ocm.invite.v1beta1.GetRemoteUserResponse"><span class="badge">M</span>GetRemoteUserResponse</a>
-                </li>
-
-                <li>
-                    <a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest"><span class="badge">M</span>GetAcceptedUsersRequest</a>
-                </li>
-
-                <li>
-                    <a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse"><span class="badge">M</span>GetAcceptedUsersResponse</a>
                 </li>
               
               
@@ -2844,14 +2844,11 @@ When a user has access to multiple storage providers, one of them is the home.
                 <td>GetRemoteUser</td>
                 <td><a href="#cs3.ocm.invite.v1beta1.GetRemoteUserRequest">.cs3.ocm.invite.v1beta1.GetRemoteUserRequest</a></td>
                 <td><a href="#cs3.ocm.invite.v1beta1.GetRemoteUserResponse">.cs3.ocm.invite.v1beta1.GetRemoteUserResponse</a></td>
-                <td><p>Retrieves details about a remote user who has accepted an invite to share.</p></td>
-              </tr>
+                <td><p>Retrieves details about a remote user who has accepted an invite to share.
 
-              <tr>
-                <td>GetAcceptedUsers</td>
-                <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">.cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest</a></td>
-                <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">.cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse</a></td>
-                <td><p>Retrieves a list of users that accepted a certain invite token.</p></td>
+*****************************************************************/
+******************** OCM PROVIDER AUTHORIZER ********************/
+*****************************************************************/</p></td>
               </tr>
             
               <tr>
@@ -6377,6 +6374,80 @@ The generated token. </p></td>
 
         
       
+        <h3 id="cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">GetAcceptedUsersRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>token_name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The token name to search accepted users for. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">GetAcceptedUsersResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>accepted_users</td>
+                  <td><a href="#cs3.identity.user.v1beta1.User">cs3.identity.user.v1beta1.User</a></td>
+                  <td>repeated</td>
+                  <td><p>REQUIRED.
+The users that accepted the token with the given name. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.ocm.invite.v1beta1.GetRemoteUserRequest">GetRemoteUserRequest</h3>
         <p></p>
 
@@ -6447,86 +6518,17 @@ The user information. </p></td>
             </tbody>
           </table>
 
+          
 
+        
+      
 
+      
 
+      
 
-
-    <h3 id="cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">GetAcceptedUsersRequest</h3>
-    <p></p>
-
-
-    <table class="field-table">
-        <thead>
-        <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-        </thead>
-        <tbody>
-
-        <tr>
-            <td>opaque</td>
-            <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-            <td></td>
-            <td><p>OPTIONAL.
-                Opaque information. </p></td>
-        </tr>
-
-        <tr>
-            <td>token_name</td>
-            <td><a href="#string">string</a></td>
-            <td></td>
-            <td><p>REQUIRED.
-                The token name to search accepted users for. </p></td>
-        </tr>
-
-        </tbody>
-    </table>
-
-
-
-
-
-    <h3 id="cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">GetAcceptedUsersResponse</h3>
-    <p></p>
-
-
-    <table class="field-table">
-        <thead>
-        <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-        </thead>
-        <tbody>
-
-        <tr>
-            <td>status</td>
-            <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
-            <td></td>
-            <td><p>REQUIRED.
-                The response status. </p></td>
-        </tr>
-
-        <tr>
-            <td>opaque</td>
-            <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-            <td></td>
-            <td><p>OPTIONAL.
-                Opaque information. </p></td>
-        </tr>
-
-        <tr>
-            <td>accepted_users</td>
-            <td><a href="#cs3.identity.user.v1beta1.User">cs3.identity.user.v1beta1.User</a></td>
-            <td>repeated</td>
-            <td><p>REQUIRED.
-                The users that accepted the token with the given name. </p></td>
-        </tr>
-
-        </tbody>
-    </table>
-
-
-
-
-
-    <h3 id="cs3.ocm.invite.v1beta1.InviteAPI">InviteAPI</h3>
+      
+        <h3 id="cs3.ocm.invite.v1beta1.InviteAPI">InviteAPI</h3>
         <p>Invite API</p><p>The Invite API is meant to invite users and groups belonging to other</p><p>sync'n'share systems, so that collaboration of resources can be enabled.</p><p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL</p><p>NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and</p><p>"OPTIONAL" in this document are to be interpreted as described in</p><p>RFC 2119.</p><p>The following are global requirements that apply to all methods:</p><p>Any method MUST return CODE_OK on a succesful operation.</p><p>Any method MAY return NOT_IMPLEMENTED.</p><p>Any method MAY return INTERNAL.</p><p>Any method MAY return UNKNOWN.</p><p>Any method MAY return UNAUTHENTICATED.</p>
         <table class="enum-table">
           <thead>
@@ -6561,13 +6563,14 @@ The user information. </p></td>
                 <td><a href="#cs3.ocm.invite.v1beta1.GetRemoteUserResponse">GetRemoteUserResponse</a></td>
                 <td><p>Retrieves details about a remote user who has accepted an invite to share.</p></td>
               </tr>
-
+            
               <tr>
-                  <td>GetAcceptedUsers</td>
-                  <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">GetAcceptedUsersRequest</a></td>
-                  <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">GetAcceptedUsersResponse</a></td>
-                  <td><p>Retrieves a list of users that accepted a certain invite token.</p></td>
+                <td>GetAcceptedUsers</td>
+                <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersRequest">GetAcceptedUsersRequest</a></td>
+                <td><a href="#cs3.ocm.invite.v1beta1.GetAcceptedUsersResponse">GetAcceptedUsersResponse</a></td>
+                <td><p>Retrieves a list of users that accepted a certain invite token.</p></td>
               </tr>
+            
           </tbody>
         </table>
 
@@ -6613,14 +6616,15 @@ The user who created the token. </p></td>
                   <td><p>OPTIONAL.
 The time when the token will expire. </p></td>
                 </tr>
-
+              
                 <tr>
-                    <td>name</td>
-                    <td><a href="#string">string</a></td>
-                    <td></td>
-                    <td><p>REQUIRED.
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
 User-defined token name for token identification. </p></td>
                 </tr>
+              
             </tbody>
           </table>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -10280,8 +10280,7 @@ Last modification time of the share. </p></td>
                   <td>share_type</td>
                   <td><a href="#cs3.sharing.ocm.v1beta1.Share.ShareType">Share.ShareType</a></td>
                   <td></td>
-                  <td><p>Specifies the type of the share so
-the service implementor can act accordingly. </p></td>
+                  <td><p>Specifies the type of the share. </p></td>
                 </tr>
               
             </tbody>
@@ -10455,7 +10454,7 @@ make the share unique. </p></td>
 
       
         <h3 id="cs3.sharing.ocm.v1beta1.Share.ShareType">Share.ShareType</h3>
-        <p>Share type defines purpose.</p>
+        <p>Defines the type of share based on its origin.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1251,6 +1251,10 @@
               
               
                 <li>
+                  <a href="#cs3.sharing.ocm.v1beta1.Share.ShareType"><span class="badge">E</span>Share.ShareType</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.sharing.ocm.v1beta1.ShareState"><span class="badge">E</span>ShareState</a>
                 </li>
               
@@ -10268,6 +10272,14 @@ Creation time of the share. </p></td>
 Last modification time of the share. </p></td>
                 </tr>
               
+                <tr>
+                  <td>share_type</td>
+                  <td><a href="#cs3.sharing.ocm.v1beta1.Share.ShareType">Share.ShareType</a></td>
+                  <td></td>
+                  <td><p>Specifies the type of the share so
+the service implementor can act accordingly. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -10437,6 +10449,35 @@ make the share unique. </p></td>
         
       
 
+      
+        <h3 id="cs3.sharing.ocm.v1beta1.Share.ShareType">Share.ShareType</h3>
+        <p>Share type defines purpose.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>SHARE_TYPE_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SHARE_TYPE_REGULAR</td>
+                <td>1</td>
+                <td><p>A regular file or folder share.</p></td>
+              </tr>
+            
+              <tr>
+                <td>SHARE_TYPE_TRANSFER</td>
+                <td>2</td>
+                <td><p>A file or folder transfer.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
       
         <h3 id="cs3.sharing.ocm.v1beta1.ShareState">ShareState</h3>
         <p>The state of the share.</p>


### PR DESCRIPTION
It should be possible to persist the purpose of the share together with the share itself, so the application can act accordingly when eg. a received share is accepted. For this the `share_type` field is defined. 
Currently `SHARE` and `TRANSFER` share types are acknowledged.
See https://github.com/cs3org/reva/pull/1242#issuecomment-788932923.