### PR TITLE
add etag to versions

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -294,6 +294,10 @@ message FileVersion {
   // REQUIRED.
   // The Unix Epoch timestamp in seconds.
   uint64 mtime = 5;
+  // REQUIRED.
+  // As decribed in https://tools.ietf.org/html/rfc7232#section-2.3
+  // For a file version, the etag does not change because a version is immutable.
+  string etag = 6;
 }
 
 // A recycle item represents the information

--- a/docs/index.html
+++ b/docs/index.html
@@ -13391,6 +13391,15 @@ The size in bytes of the file version. </p></td>
 The Unix Epoch timestamp in seconds. </p></td>
                 </tr>
               
+                <tr>
+                  <td>etag</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+As decribed in https://tools.ietf.org/html/rfc7232#section-2.3
+For a file version, the etag does not change because a version is immutable. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -13558,7 +13567,8 @@ The key to identify the deleted resource. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>REQUIRED.
-The original path of the deleted resource. </p></td>
+The original path of the deleted resource.
+MUST start with the slash character (/). </p></td>
                 </tr>
               
                 <tr>


### PR DESCRIPTION
FileVersion must have an Etag property so that oCIS can provide them on the file versions endpoint (https://doc.owncloud.com/server/developer_manual/webdav_api/files_versions.html#file-is-found-and-has-multiple-versions).

Implementation WIP in Reva: https://github.com/cs3org/reva/pull/1526/commits/f2cadc43cf47c090dccbe35399393d78f19937f2