### PR TITLE
Match multiple storage providers in registry

### DIFF
--- a/cs3/gateway/v1beta1/resources.proto
+++ b/cs3/gateway/v1beta1/resources.proto
@@ -28,7 +28,6 @@ option java_package = "com.cs3.gateway.v1beta1";
 option objc_class_prefix = "CGX";
 option php_namespace = "Cs3\\Gateway\\V1Beta1";
 
-import "cs3/rpc/v1beta1/status.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 

--- a/cs3/ocm/invite/v1beta1/resources.proto
+++ b/cs3/ocm/invite/v1beta1/resources.proto
@@ -29,7 +29,6 @@ option objc_class_prefix = "COI";
 option php_namespace = "Cs3\\Ocm\\Invite\\V1Beta1";
 
 import "cs3/identity/user/v1beta1/resources.proto";
-import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 
 // InviteToken is used to invite users and groups from other sync'n'share

--- a/cs3/storage/registry/v1beta1/registry_api.proto
+++ b/cs3/storage/registry/v1beta1/registry_api.proto
@@ -53,7 +53,7 @@ service RegistryAPI {
   // Returns the storage provider that is reponsible for the given
   // resource reference.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  rpc GetStorageProvider(GetStorageProviderRequest) returns (GetStorageProviderResponse);
+  rpc GetStorageProviders(GetStorageProvidersRequest) returns (GetStorageProvidersResponse);
   // Returns a list of the available storage providers known by this registry.
   rpc ListStorageProviders(ListStorageProvidersRequest) returns (ListStorageProvidersResponse);
   // Gets the user home storage provider.
@@ -81,7 +81,7 @@ message GetHomeResponse {
   cs3.storage.registry.v1beta1.ProviderInfo provider = 3;
 }
 
-message GetStorageProviderRequest {
+message GetStorageProvidersRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
@@ -90,7 +90,7 @@ message GetStorageProviderRequest {
   cs3.storage.provider.v1beta1.Reference ref = 2;
 }
 
-message GetStorageProviderResponse {
+message GetStorageProvidersResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -98,8 +98,8 @@ message GetStorageProviderResponse {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
-  // The storage provider handling the requested storage resource.
-  cs3.storage.registry.v1beta1.ProviderInfo provider = 3;
+  // The storage providers handling the requested storage resource.
+  repeated cs3.storage.registry.v1beta1.ProviderInfo providers = 3;
 }
 
 message ListStorageProvidersRequest {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1635,11 +1635,11 @@
                 </li>
               
                 <li>
-                  <a href="#cs3.storage.registry.v1beta1.GetStorageProviderRequest"><span class="badge">M</span>GetStorageProviderRequest</a>
+                  <a href="#cs3.storage.registry.v1beta1.GetStorageProvidersRequest"><span class="badge">M</span>GetStorageProvidersRequest</a>
                 </li>
               
                 <li>
-                  <a href="#cs3.storage.registry.v1beta1.GetStorageProviderResponse"><span class="badge">M</span>GetStorageProviderResponse</a>
+                  <a href="#cs3.storage.registry.v1beta1.GetStorageProvidersResponse"><span class="badge">M</span>GetStorageProvidersResponse</a>
                 </li>
               
                 <li>
@@ -14353,7 +14353,7 @@ The storage provider for the user home. </p></td>
 
         
       
-        <h3 id="cs3.storage.registry.v1beta1.GetStorageProviderRequest">GetStorageProviderRequest</h3>
+        <h3 id="cs3.storage.registry.v1beta1.GetStorageProvidersRequest">GetStorageProvidersRequest</h3>
         <p></p>
 
         
@@ -14386,7 +14386,7 @@ The reference for the resource. </p></td>
 
         
       
-        <h3 id="cs3.storage.registry.v1beta1.GetStorageProviderResponse">GetStorageProviderResponse</h3>
+        <h3 id="cs3.storage.registry.v1beta1.GetStorageProvidersResponse">GetStorageProvidersResponse</h3>
         <p></p>
 
         
@@ -14413,11 +14413,11 @@ Opaque information. </p></td>
                 </tr>
               
                 <tr>
-                  <td>provider</td>
+                  <td>providers</td>
                   <td><a href="#cs3.storage.registry.v1beta1.ProviderInfo">ProviderInfo</a></td>
-                  <td></td>
+                  <td>repeated</td>
                   <td><p>REQUIRED.
-The storage provider handling the requested storage resource. </p></td>
+The storage providers handling the requested storage resource. </p></td>
                 </tr>
               
             </tbody>
@@ -14510,9 +14510,9 @@ The list of storage providers this registry knows about. </p></td>
           <tbody>
             
               <tr>
-                <td>GetStorageProvider</td>
-                <td><a href="#cs3.storage.registry.v1beta1.GetStorageProviderRequest">GetStorageProviderRequest</a></td>
-                <td><a href="#cs3.storage.registry.v1beta1.GetStorageProviderResponse">GetStorageProviderResponse</a></td>
+                <td>GetStorageProviders</td>
+                <td><a href="#cs3.storage.registry.v1beta1.GetStorageProvidersRequest">GetStorageProvidersRequest</a></td>
+                <td><a href="#cs3.storage.registry.v1beta1.GetStorageProvidersResponse">GetStorageProvidersResponse</a></td>
                 <td><p>Returns the storage provider that is reponsible for the given
 resource reference.
 MUST return CODE_NOT_FOUND if the reference does not exist.</p></td>

--- a/proto.lock
+++ b/proto.lock
@@ -1462,9 +1462,6 @@
         ],
         "imports": [
           {
-            "path": "cs3/rpc/v1beta1/status.proto"
-          },
-          {
             "path": "cs3/storage/provider/v1beta1/resources.proto"
           },
           {
@@ -2708,9 +2705,6 @@
         "imports": [
           {
             "path": "cs3/identity/user/v1beta1/resources.proto"
-          },
-          {
-            "path": "cs3/storage/provider/v1beta1/resources.proto"
           },
           {
             "path": "cs3/types/v1beta1/types.proto"
@@ -4344,6 +4338,11 @@
                 "id": 3,
                 "name": "share",
                 "type": "PublicShare"
+              },
+              {
+                "id": 4,
+                "name": "password_hash",
+                "type": "string"
               }
             ]
           },
@@ -4384,6 +4383,11 @@
                 "id": 3,
                 "name": "share",
                 "type": "PublicShare"
+              },
+              {
+                "id": 4,
+                "name": "password_hash",
+                "type": "string"
               }
             ]
           }
@@ -7089,6 +7093,11 @@
                 "id": 5,
                 "name": "mtime",
                 "type": "uint64"
+              },
+              {
+                "id": 6,
+                "name": "etag",
+                "type": "string"
               }
             ]
           },
@@ -7340,7 +7349,7 @@
             ]
           },
           {
-            "name": "GetStorageProviderRequest",
+            "name": "GetStorageProvidersRequest",
             "fields": [
               {
                 "id": 1,
@@ -7355,7 +7364,7 @@
             ]
           },
           {
-            "name": "GetStorageProviderResponse",
+            "name": "GetStorageProvidersResponse",
             "fields": [
               {
                 "id": 1,
@@ -7369,8 +7378,9 @@
               },
               {
                 "id": 3,
-                "name": "provider",
-                "type": "cs3.storage.registry.v1beta1.ProviderInfo"
+                "name": "providers",
+                "type": "cs3.storage.registry.v1beta1.ProviderInfo",
+                "is_repeated": true
               }
             ]
           },
@@ -7411,9 +7421,9 @@
             "name": "RegistryAPI",
             "rpcs": [
               {
-                "name": "GetStorageProvider",
-                "in_type": "GetStorageProviderRequest",
-                "out_type": "GetStorageProviderResponse"
+                "name": "GetStorageProviders",
+                "in_type": "GetStorageProvidersRequest",
+                "out_type": "GetStorageProvidersResponse"
               },
               {
                 "name": "ListStorageProviders",


### PR DESCRIPTION
For cases where users are sharded across multiple storage providers, we need to match multiple such providers for a given reference and merge the results obtained from these. This is especially useful for listing, deleting sharded containers, etc.