### PR TITLE
Support signature authentication for public links

### DIFF
--- a/cs3/sharing/link/v1beta1/link_api.proto
+++ b/cs3/sharing/link/v1beta1/link_api.proto
@@ -173,6 +173,9 @@ message ListPublicSharesRequest {
   // OPTIONAL.
   // The list of filters to apply if any.
   repeated Filter filters = 2;
+  // OPTIONAL.
+  // If a signature should be included in the share.
+  bool sign = 3;
 }
 
 message ListPublicSharesResponse {
@@ -212,6 +215,9 @@ message GetPublicShareRequest {
   // REQUIRED.
   // The reference to which the action should be performed.
   PublicShareReference ref = 2;
+  // OPTIONAL.
+  // If a signature should be included in the share.
+  bool sign = 3;
 }
 
 message GetPublicShareResponse {
@@ -224,9 +230,6 @@ message GetPublicShareResponse {
   // REQUIRED.
   // The share.
   PublicShare share = 3;
-  // OPTIONAL.
-  // The share password hash.
-  string password_hash = 4;
 }
 
 message GetPublicShareByTokenRequest {
@@ -237,8 +240,11 @@ message GetPublicShareByTokenRequest {
   // The unlisted token to identify the public share.
   string token = 2;
   // OPTIONAL.
-  // The public link can be password protected.
-  string password = 3;
+  // The public link can require authentication.
+  PublicShareAuthentication authentication = 3;
+  // OPTIONAL.
+  // If a signature should be included in the share.
+  bool sign = 4;
 }
 
 message GetPublicShareByTokenResponse {
@@ -253,5 +259,5 @@ message GetPublicShareByTokenResponse {
   PublicShare share = 3;
   // OPTIONAL.
   // The share password hash.
-  string password_hash = 4;
+  string password_hash = 4 [deprecated = true];
 }

--- a/cs3/sharing/link/v1beta1/resources.proto
+++ b/cs3/sharing/link/v1beta1/resources.proto
@@ -98,6 +98,11 @@ message PublicShare {
   // This field is only useful for informational purposes, like for example,
   // setting the window title in a public share HTML page.
   string display_name = 11;
+  // OPTIONAL.
+  // A time constrained token with which
+  // GetPublicSharebyToken requests can be
+  // authenticated.
+  ShareSignature signature = 12;
 }
 
 // The permissions for a share.
@@ -128,6 +133,28 @@ message PublicShareReference {
     // The token to identify the public share.
     string token = 2;
   }
+}
+
+// The mechanism to authenticate a request to
+// GetPublicShareByToken.
+message PublicShareAuthentication {
+  oneof spec {
+    // The password of the share.
+    string password = 1;
+    // The signature issued by GetPublicShareByToken.
+    ShareSignature signature = 2;
+  }
+}
+
+// A time constrained token which can be used to
+// authenticate link share requests.
+message ShareSignature {
+  // REQUIRED.
+  // The signature value.
+  string signature = 1;
+  // REQUIRED.
+  // The time until the signature becomes invalid.
+  cs3.types.v1beta1.Timestamp signature_expiration = 2;
 }
 
 // Defines the restrictions for the public share.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1104,6 +1104,10 @@
                 </li>
               
                 <li>
+                  <a href="#cs3.sharing.link.v1beta1.PublicShareAuthentication"><span class="badge">M</span>PublicShareAuthentication</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.sharing.link.v1beta1.PublicShareId"><span class="badge">M</span>PublicShareId</a>
                 </li>
               
@@ -1113,6 +1117,10 @@
               
                 <li>
                   <a href="#cs3.sharing.link.v1beta1.PublicShareReference"><span class="badge">M</span>PublicShareReference</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.sharing.link.v1beta1.ShareSignature"><span class="badge">M</span>ShareSignature</a>
                 </li>
               
               
@@ -8482,11 +8490,19 @@ The unlisted token to identify the public share. </p></td>
                 </tr>
               
                 <tr>
-                  <td>password</td>
-                  <td><a href="#string">string</a></td>
+                  <td>authentication</td>
+                  <td><a href="#cs3.sharing.link.v1beta1.PublicShareAuthentication">PublicShareAuthentication</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-The public link can be password protected. </p></td>
+The public link can require authentication. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sign</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+If a signature should be included in the share. </p></td>
                 </tr>
               
             </tbody>
@@ -8542,6 +8558,27 @@ The share password hash. </p></td>
           </table>
 
           
+            
+            
+            <h4>Fields with deprecated option</h4>
+            <table>
+              <thead>
+                <tr>
+                  <td>Name</td>
+                  <td>Option</td>
+                </tr>
+              </thead>
+              <tbody>
+              
+                <tr>
+                  <td>password_hash</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+              </tbody>
+            </table>
+            
+          
 
         
       
@@ -8569,6 +8606,14 @@ Opaque information. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The reference to which the action should be performed. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sign</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+If a signature should be included in the share. </p></td>
                 </tr>
               
             </tbody>
@@ -8612,14 +8657,6 @@ Opaque information. </p></td>
 The share. </p></td>
                 </tr>
               
-                <tr>
-                  <td>password_hash</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-The share password hash. </p></td>
-                </tr>
-              
             </tbody>
           </table>
 
@@ -8651,6 +8688,14 @@ Opaque information. </p></td>
                   <td>repeated</td>
                   <td><p>OPTIONAL.
 The list of filters to apply if any. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>sign</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+If a signature should be included in the share. </p></td>
                 </tr>
               
             </tbody>
@@ -9243,6 +9288,47 @@ This field is only useful for informational purposes, like for example,
 setting the window title in a public share HTML page. </p></td>
                 </tr>
               
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#cs3.sharing.link.v1beta1.ShareSignature">ShareSignature</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A time constrained token with which
+GetPublicSharebyToken requests can be
+authenticated. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.sharing.link.v1beta1.PublicShareAuthentication">PublicShareAuthentication</h3>
+        <p>The mechanism to authenticate a request to</p><p>GetPublicShareByToken.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>password</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The password of the share. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#cs3.sharing.link.v1beta1.ShareSignature">ShareSignature</a></td>
+                  <td></td>
+                  <td><p>The signature issued by GetPublicShareByToken. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -9323,6 +9409,39 @@ implementation of the service. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The token to identify the public share. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.sharing.link.v1beta1.ShareSignature">ShareSignature</h3>
+        <p>A time constrained token which can be used to</p><p>authenticate link share requests.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The signature value. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signature_expiration</td>
+                  <td><a href="#cs3.types.v1beta1.Timestamp">cs3.types.v1beta1.Timestamp</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The time until the signature becomes invalid. </p></td>
                 </tr>
               
             </tbody>

--- a/proto.lock
+++ b/proto.lock
@@ -3279,6 +3279,10 @@
               {
                 "name": "CODE_REDIRECTION",
                 "integer": 18
+              },
+              {
+                "name": "CODE_INSUFFICIENT_STORAGE",
+                "integer": 19
               }
             ]
           }
@@ -4225,6 +4229,11 @@
                 "name": "filters",
                 "type": "Filter",
                 "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "sign",
+                "type": "bool"
               }
             ],
             "messages": [
@@ -4318,6 +4327,11 @@
                 "id": 2,
                 "name": "ref",
                 "type": "PublicShareReference"
+              },
+              {
+                "id": 3,
+                "name": "sign",
+                "type": "bool"
               }
             ]
           },
@@ -4338,11 +4352,6 @@
                 "id": 3,
                 "name": "share",
                 "type": "PublicShare"
-              },
-              {
-                "id": 4,
-                "name": "password_hash",
-                "type": "string"
               }
             ]
           },
@@ -4361,8 +4370,13 @@
               },
               {
                 "id": 3,
-                "name": "password",
-                "type": "string"
+                "name": "authentication",
+                "type": "PublicShareAuthentication"
+              },
+              {
+                "id": 4,
+                "name": "sign",
+                "type": "bool"
               }
             ]
           },
@@ -4387,7 +4401,13 @@
               {
                 "id": 4,
                 "name": "password_hash",
-                "type": "string"
+                "type": "string",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ]
           }
@@ -4542,6 +4562,11 @@
                 "id": 11,
                 "name": "display_name",
                 "type": "string"
+              },
+              {
+                "id": 12,
+                "name": "signature",
+                "type": "ShareSignature"
               }
             ]
           },
@@ -4577,6 +4602,36 @@
                 "id": 2,
                 "name": "token",
                 "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PublicShareAuthentication",
+            "fields": [
+              {
+                "id": 1,
+                "name": "password",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "signature",
+                "type": "ShareSignature"
+              }
+            ]
+          },
+          {
+            "name": "ShareSignature",
+            "fields": [
+              {
+                "id": 1,
+                "name": "signature",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "signature_expiration",
+                "type": "cs3.types.v1beta1.Timestamp"
               }
             ]
           },


### PR DESCRIPTION
Deprecated the changes from https://github.com/cs3org/cs3apis/pull/113
and enhanced the api to support signature based authentication for
public links.