### PR TITLE
Added a new OpenInApp request/response

### DIFF
--- a/cs3/app/provider/v1beta1/provider_api.proto
+++ b/cs3/app/provider/v1beta1/provider_api.proto
@@ -52,9 +52,62 @@ import "cs3/types/v1beta1/types.proto";
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
 service ProviderAPI {
-  // Returns the App provider URL
+  // Returns the App provider URL (deprecated)
   // MUST return CODE_NOT_FOUND if the resource does not exist.
   rpc OpenFileInAppProvider(OpenFileInAppProviderRequest) returns (OpenFileInAppProviderResponse);
+  // Returns the App provider URL
+  // MUST return CODE_NOT_FOUND if the resource does not exist.
+  rpc OpenInApp(OpenInAppRequest) returns (OpenInAppResponse);
+}
+
+message OpenInAppRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The resourceInfo to be opened. The gateway grpc message has a ref instead.
+  storage.provider.v1beta1.ResourceInfo resource_info = 2;
+  // REQUIRED.
+  // View mode.
+  enum ViewMode {
+    VIEW_MODE_INVALID = 0;
+    // The resource can be opened but not downloaded.
+    VIEW_MODE_VIEW_ONLY = 1;
+    // The resource can be downloaded.
+    VIEW_MODE_READ_ONLY = 2;
+    // The resource can be downloaded and updated.
+    VIEW_MODE_READ_WRITE = 3;
+  }
+  ViewMode view_mode = 3;
+  // REQUIRED.
+  // The access token this application provider will use when contacting
+  // the storage provider to read and write.
+  // Service implementors MUST make sure that the access token only grants
+  // access to the requested resource.
+  // Service implementors should use a ResourceId rather than a filepath to grant access, as
+  // ResourceIds MUST NOT change when a resource is renamed.
+  // The access token MUST be short-lived.
+  // TODO(labkode): investigate token derivation techniques.
+  string access_token = 4;
+  // OPTIONAL.
+  // A reference to the application to be used to open the resource, should the
+  // default inferred from the resource's mimetype be overridden by user's choice.
+  // If the targeted resource is a directory, this parameter is required and
+  // in its absence the implementation MUST return INVALID_ARGUMENT.
+  string app = 5;
+}
+
+message OpenInAppResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The url that user agents will render to clients.
+  // Usually the rendering happens by using HTML iframes or in separate browser tabs.
+  string app_url = 3;
 }
 
 message OpenFileInAppProviderRequest {

--- a/cs3/app/registry/v1beta1/registry_api.proto
+++ b/cs3/app/registry/v1beta1/registry_api.proto
@@ -82,8 +82,24 @@ message ListAppProvidersRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
-  // TODO(labkode): maybe add some filter?
-
+  // REQUIRED.
+  // Represents a filter to apply to the request.
+  message Filter {
+    // The filter to apply.
+    enum Type {
+      TYPE_INVALID = 0;
+      TYPE_MIME_TYPE = 1;
+    }
+    // REQUIRED.
+    Type type = 2;
+    oneof term {
+      // if present, the response MUST list all known app providers for the given mimetype.
+      string mime_type = 3;
+    }
+  }
+  // OPTIONAL.
+  // The list of filters to apply if any.
+  repeated Filter filters = 2;
 }
 
 message ListAppProvidersResponse {

--- a/docs/index.html
+++ b/docs/index.html
@@ -500,9 +500,21 @@
                   <a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderResponse"><span class="badge">M</span>OpenFileInAppProviderResponse</a>
                 </li>
               
+                <li>
+                  <a href="#cs3.app.provider.v1beta1.OpenInAppRequest"><span class="badge">M</span>OpenInAppRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.app.provider.v1beta1.OpenInAppResponse"><span class="badge">M</span>OpenInAppResponse</a>
+                </li>
+              
               
                 <li>
                   <a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderRequest.ViewMode"><span class="badge">E</span>OpenFileInAppProviderRequest.ViewMode</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.app.provider.v1beta1.OpenInAppRequest.ViewMode"><span class="badge">E</span>OpenInAppRequest.ViewMode</a>
                 </li>
               
               
@@ -4852,6 +4864,114 @@ Usually the rendering happens by using HTML iframes or in separate browser tabs.
 
         
       
+        <h3 id="cs3.app.provider.v1beta1.OpenInAppRequest">OpenInAppRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>resource_info</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.ResourceInfo">cs3.storage.provider.v1beta1.ResourceInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The resourceInfo to be opened. The gateway grpc message has a ref instead. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>view_mode</td>
+                  <td><a href="#cs3.app.provider.v1beta1.OpenInAppRequest.ViewMode">OpenInAppRequest.ViewMode</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>access_token</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The access token this application provider will use when contacting
+the storage provider to read and write.
+Service implementors MUST make sure that the access token only grants
+access to the requested resource.
+Service implementors should use a ResourceId rather than a filepath to grant access, as
+ResourceIds MUST NOT change when a resource is renamed.
+The access token MUST be short-lived.
+TODO(labkode): investigate token derivation techniques. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>app</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A reference to the application to be used to open the resource, should the
+default inferred from the resource&#39;s mimetype be overridden by user&#39;s choice.
+If the targeted resource is a directory, this parameter is required and
+in its absence the implementation MUST return INVALID_ARGUMENT. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.app.provider.v1beta1.OpenInAppResponse">OpenInAppResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>app_url</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The url that user agents will render to clients.
+Usually the rendering happens by using HTML iframes or in separate browser tabs. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
 
       
         <h3 id="cs3.app.provider.v1beta1.OpenFileInAppProviderRequest.ViewMode">OpenFileInAppProviderRequest.ViewMode</h3>
@@ -4889,6 +5009,41 @@ Usually the rendering happens by using HTML iframes or in separate browser tabs.
           </tbody>
         </table>
       
+        <h3 id="cs3.app.provider.v1beta1.OpenInAppRequest.ViewMode">OpenInAppRequest.ViewMode</h3>
+        <p>REQUIRED.</p><p>View mode.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>VIEW_MODE_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>VIEW_MODE_VIEW_ONLY</td>
+                <td>1</td>
+                <td><p>The resource can be opened but not downloaded.</p></td>
+              </tr>
+            
+              <tr>
+                <td>VIEW_MODE_READ_ONLY</td>
+                <td>2</td>
+                <td><p>The resource can be downloaded.</p></td>
+              </tr>
+            
+              <tr>
+                <td>VIEW_MODE_READ_WRITE</td>
+                <td>3</td>
+                <td><p>The resource can be downloaded and updated.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
 
       
 
@@ -4905,6 +5060,14 @@ Usually the rendering happens by using HTML iframes or in separate browser tabs.
                 <td>OpenFileInAppProvider</td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderRequest">OpenFileInAppProviderRequest</a></td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenFileInAppProviderResponse">OpenFileInAppProviderResponse</a></td>
+                <td><p>Returns the App provider URL (deprecated)
+MUST return CODE_NOT_FOUND if the resource does not exist.</p></td>
+              </tr>
+            
+              <tr>
+                <td>OpenInApp</td>
+                <td><a href="#cs3.app.provider.v1beta1.OpenInAppRequest">OpenInAppRequest</a></td>
+                <td><a href="#cs3.app.provider.v1beta1.OpenInAppResponse">OpenInAppResponse</a></td>
                 <td><p>Returns the App provider URL
 MUST return CODE_NOT_FOUND if the resource does not exist.</p></td>
               </tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -544,9 +544,17 @@
                 </li>
               
                 <li>
+                  <a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter"><span class="badge">M</span>ListAppProvidersRequest.Filter</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.app.registry.v1beta1.ListAppProvidersResponse"><span class="badge">M</span>ListAppProvidersResponse</a>
                 </li>
               
+              
+                <li>
+                  <a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter.Type"><span class="badge">E</span>ListAppProvidersRequest.Filter.Type</a>
+                </li>
               
               
               
@@ -5173,9 +5181,46 @@ The app providers available for the given resource info. </p></td>
                   <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-Opaque information.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>filters</td>
+                  <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter">ListAppProvidersRequest.Filter</a></td>
+                  <td>repeated</td>
+                  <td><p>OPTIONAL.
+The list of filters to apply if any. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
 
-TODO(labkode): maybe add some filter? </p></td>
+          
+
+        
+      
+        <h3 id="cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter">ListAppProvidersRequest.Filter</h3>
+        <p>REQUIRED.</p><p>Represents a filter to apply to the request.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>type</td>
+                  <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter.Type">ListAppProvidersRequest.Filter.Type</a></td>
+                  <td></td>
+                  <td><p>REQUIRED. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>mime_type</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>if present, the response MUST list all known app providers for the given mimetype. </p></td>
                 </tr>
               
             </tbody>
@@ -5227,6 +5272,29 @@ The list of app providers this registry knows about. </p></td>
         
       
 
+      
+        <h3 id="cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter.Type">ListAppProvidersRequest.Filter.Type</h3>
+        <p>The filter to apply.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>TYPE_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_MIME_TYPE</td>
+                <td>1</td>
+                <td><p></p></td>
+              </tr>
+            
+          </tbody>
+        </table>
       
 
       


### PR DESCRIPTION
This will eventually supersede `OpenFileInAppProvider`.

The rationale being that `OpenInApp` generically refers to `ref`s, i.e. files AND directories, and a new optional parameter `app` was added, to allow:
1) In case of folders, to specify the app as the default logic to map mimetypes to apps cannot apply
2) In case of files, to allow overriding the default logic and support the case where the user asks to "Open with..." and multiple applications are registered for the same mimetype (typical case: `.docx` -> MS Office Online, OnlyOffice, Collabora Online).
