### PR TITLE
Extend InitiateFileUpload to support exclusive uploads and etags-based checks

### DIFF
--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -280,6 +280,13 @@ message InitiateFileUploadRequest {
   // REQUIRED.
   // The reference to which the action should be performed.
   Reference ref = 2;
+  // OPTIONAL.
+  // Whether the file is to be uploaded in exclusive mode. Defaults to false.
+  // If true, the request SHALL be processed such that only one of multiple concurrent uploads
+  // to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
+  // The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
+  // The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode.
+  bool exclusive = 3;
 }
 
 message InitiateFileUploadResponse {

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -280,18 +280,20 @@ message InitiateFileUploadRequest {
   // REQUIRED.
   // The reference to which the action should be performed.
   Reference ref = 2;
-  // OPTIONAL.
-  // Whether the file is to be uploaded in exclusive mode. Defaults to false.
-  // If true, the request SHALL be processed such that only one of multiple concurrent uploads
-  // to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
-  // The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
-  // The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode.
-  bool if_not_exist = 3;
-  // OPTIONAL.
-  // Whether the file is to be uploaded if the given etag matches. Default to always upload.
-  // If a mismatching etag is given, the request MUST return CODE_ALREADY_EXISTS with the current etag
-  // in the opaque field.
-  string if_match = 4;
+  oneof options {
+    // OPTIONAL.
+    // Whether the file is to be uploaded in exclusive mode. Defaults to false.
+    // If true, the request SHALL be processed such that only one of multiple concurrent uploads
+    // to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
+    // The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
+    // The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode.
+    bool if_not_exist = 3;
+    // OPTIONAL.
+    // Whether the file is to be uploaded if the given etag matches. Default to always upload.
+    // If a mismatching etag is given, the request MUST return CODE_ALREADY_EXISTS with the current etag
+    // in the opaque field.
+    string if_match = 4;
+  }
 }
 
 message InitiateFileUploadResponse {

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -286,7 +286,12 @@ message InitiateFileUploadRequest {
   // to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
   // The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
   // The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode.
-  bool exclusive = 3;
+  bool if_not_exist = 3;
+  // OPTIONAL.
+  // Whether the file is to be uploaded if the given etag matches. Default to always upload.
+  // If a mismatching etag is given, the request MUST return CODE_ALREADY_EXISTS with the current etag
+  // in the opaque field.
+  string if_match = 4;
 }
 
 message InitiateFileUploadResponse {

--- a/docs/index.html
+++ b/docs/index.html
@@ -11723,6 +11723,18 @@ Opaque information. </p></td>
 The reference to which the action should be performed. </p></td>
                 </tr>
               
+                <tr>
+                  <td>exclusive</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Whether the file is to be uploaded in exclusive mode. Defaults to false.
+If true, the request SHALL be processed such that only one of multiple concurrent uploads
+to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
+The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
+The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -11723,18 +11723,6 @@ Opaque information. </p></td>
 The reference to which the action should be performed. </p></td>
                 </tr>
               
-                <tr>
-                  <td>exclusive</td>
-                  <td><a href="#bool">bool</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Whether the file is to be uploaded in exclusive mode. Defaults to false.
-If true, the request SHALL be processed such that only one of multiple concurrent uploads
-to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
-The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
-The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode. </p></td>
-                </tr>
-              
             </tbody>
           </table>
 
@@ -12605,6 +12593,28 @@ Opaque information. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The reference to which the action should be performed. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>if_not_exist</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Whether the file is to be uploaded in exclusive mode. Defaults to false.
+If true, the request SHALL be processed such that only one of multiple concurrent uploads
+to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
+The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
+The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>if_match</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Whether the file is to be uploaded if the given etag matches. Default to always upload.
+If a mismatching etag is given, the request MUST return CODE_ALREADY_EXISTS with the current etag
+in the opaque field. </p></td>
                 </tr>
               
             </tbody>

--- a/proto.lock
+++ b/proto.lock
@@ -354,6 +354,26 @@
       "def": {
         "enums": [
           {
+            "name": "OpenInAppRequest.ViewMode",
+            "enum_fields": [
+              {
+                "name": "VIEW_MODE_INVALID"
+              },
+              {
+                "name": "VIEW_MODE_VIEW_ONLY",
+                "integer": 1
+              },
+              {
+                "name": "VIEW_MODE_READ_ONLY",
+                "integer": 2
+              },
+              {
+                "name": "VIEW_MODE_READ_WRITE",
+                "integer": 3
+              }
+            ]
+          },
+          {
             "name": "OpenFileInAppProviderRequest.ViewMode",
             "enum_fields": [
               {
@@ -375,6 +395,56 @@
           }
         ],
         "messages": [
+          {
+            "name": "OpenInAppRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "resource_info",
+                "type": "storage.provider.v1beta1.ResourceInfo"
+              },
+              {
+                "id": 3,
+                "name": "view_mode",
+                "type": "ViewMode"
+              },
+              {
+                "id": 4,
+                "name": "access_token",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "app",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "OpenInAppResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "app_url",
+                "type": "string"
+              }
+            ]
+          },
           {
             "name": "OpenFileInAppProviderRequest",
             "fields": [
@@ -429,6 +499,11 @@
                 "name": "OpenFileInAppProvider",
                 "in_type": "OpenFileInAppProviderRequest",
                 "out_type": "OpenFileInAppProviderResponse"
+              },
+              {
+                "name": "OpenInApp",
+                "in_type": "OpenInAppRequest",
+                "out_type": "OpenInAppResponse"
               }
             ]
           }
@@ -482,6 +557,20 @@
     {
       "protopath": "cs3:/:app:/:registry:/:v1beta1:/:registry_api.proto",
       "def": {
+        "enums": [
+          {
+            "name": "Filter.Type",
+            "enum_fields": [
+              {
+                "name": "TYPE_INVALID"
+              },
+              {
+                "name": "TYPE_MIME_TYPE",
+                "integer": 1
+              }
+            ]
+          }
+        ],
         "messages": [
           {
             "name": "GetAppProvidersRequest",
@@ -526,6 +615,29 @@
                 "id": 1,
                 "name": "opaque",
                 "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "filters",
+                "type": "Filter",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "Filter",
+                "fields": [
+                  {
+                    "id": 2,
+                    "name": "type",
+                    "type": "Type"
+                  },
+                  {
+                    "id": 3,
+                    "name": "mime_type",
+                    "type": "string"
+                  }
+                ]
               }
             ]
           },
@@ -2237,6 +2349,44 @@
     {
       "protopath": "cs3:/:identity:/:user:/:v1beta1:/:resources.proto",
       "def": {
+        "enums": [
+          {
+            "name": "UserType",
+            "enum_fields": [
+              {
+                "name": "USER_TYPE_INVALID"
+              },
+              {
+                "name": "USER_TYPE_PRIMARY",
+                "integer": 1
+              },
+              {
+                "name": "USER_TYPE_SECONDARY",
+                "integer": 2
+              },
+              {
+                "name": "USER_TYPE_SERVICE",
+                "integer": 3
+              },
+              {
+                "name": "USER_TYPE_APPLICATION",
+                "integer": 4
+              },
+              {
+                "name": "USER_TYPE_GUEST",
+                "integer": 5
+              },
+              {
+                "name": "USER_TYPE_FEDERATED",
+                "integer": 6
+              },
+              {
+                "name": "USER_TYPE_LIGHTWEIGHT",
+                "integer": 7
+              }
+            ]
+          }
+        ],
         "messages": [
           {
             "name": "UserId",
@@ -2250,6 +2400,11 @@
                 "id": 2,
                 "name": "opaque_id",
                 "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "UserType"
               }
             ]
           },
@@ -6010,8 +6165,13 @@
               },
               {
                 "id": 3,
-                "name": "exclusive",
+                "name": "if_not_exist",
                 "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "if_match",
+                "type": "string"
               }
             ]
           },

--- a/proto.lock
+++ b/proto.lock
@@ -1,6 +1,355 @@
 {
   "definitions": [
     {
+      "protopath": "cs3:/:admin:/:group:/:v1beta1:/:group_api.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "CreateGroupRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "group",
+                "type": "cs3.identity.group.v1beta1.Group"
+              }
+            ]
+          },
+          {
+            "name": "CreateGroupResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "group",
+                "type": "cs3.identity.group.v1beta1.Group"
+              }
+            ]
+          },
+          {
+            "name": "DeleteGroupRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              }
+            ]
+          },
+          {
+            "name": "DeleteGroupResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "AddUserToGroupRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "user_id",
+                "type": "cs3.identity.user.v1beta1.UserId"
+              },
+              {
+                "id": 2,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              },
+              {
+                "id": 3,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "AddUserToGroupResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "RemoveUserFromGroupRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "user_id",
+                "type": "cs3.identity.user.v1beta1.UserId"
+              },
+              {
+                "id": 2,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              },
+              {
+                "id": 3,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "RemoveUserFromGroupResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "GroupAPI",
+            "rpcs": [
+              {
+                "name": "CreateGroup",
+                "in_type": "CreateGroupRequest",
+                "out_type": "CreateGroupResponse"
+              },
+              {
+                "name": "DeleteGroup",
+                "in_type": "DeleteGroupRequest",
+                "out_type": "DeleteGroupResponse"
+              },
+              {
+                "name": "AddUserToGroup",
+                "in_type": "AddUserToGroupRequest",
+                "out_type": "AddUserToGroupResponse"
+              },
+              {
+                "name": "RemoveUserFromGroup",
+                "in_type": "RemoveUserFromGroupRequest",
+                "out_type": "RemoveUserFromGroupResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "cs3/identity/group/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/identity/user/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/rpc/v1beta1/status.proto"
+          },
+          {
+            "path": "cs3/types/v1beta1/types.proto"
+          }
+        ],
+        "package": {
+          "name": "cs3.admin.group.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Admin.Group.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "groupv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "GroupApiProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.admin.group.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CAG"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Admin\\\\Group\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "cs3:/:admin:/:user:/:v1beta1:/:user_api.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "CreateUserRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "user",
+                "type": "cs3.identity.user.v1beta1.User"
+              }
+            ]
+          },
+          {
+            "name": "CreateUserResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "user",
+                "type": "cs3.identity.user.v1beta1.User"
+              }
+            ]
+          },
+          {
+            "name": "DeleteUserRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "user_id",
+                "type": "cs3.identity.user.v1beta1.UserId"
+              }
+            ]
+          },
+          {
+            "name": "DeleteUserResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "UserAPI",
+            "rpcs": [
+              {
+                "name": "CreateUser",
+                "in_type": "CreateUserRequest",
+                "out_type": "CreateUserResponse"
+              },
+              {
+                "name": "DeleteUser",
+                "in_type": "DeleteUserRequest",
+                "out_type": "DeleteUserResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "cs3/identity/user/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/rpc/v1beta1/status.proto"
+          },
+          {
+            "path": "cs3/types/v1beta1/types.proto"
+          }
+        ],
+        "package": {
+          "name": "cs3.admin.user.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Admin.User.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "userv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "UserApiProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.admin.user.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CAU"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Admin\\\\User\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
       "protopath": "cs3:/:app:/:provider:/:v1beta1:/:provider_api.proto",
       "def": {
         "enums": [
@@ -5658,6 +6007,11 @@
                 "id": 2,
                 "name": "ref",
                 "type": "Reference"
+              },
+              {
+                "id": 3,
+                "name": "exclusive",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
This is a revamp of https://github.com/cs3org/cs3apis/pull/87, which got closed because the `master` branch got renamed to `main`...

Pasting here the relevant parts:

This extension is motivated by cs3org/wopiserver#25. Discussing with @ishank011 it looks reasonable to extend the `InitiateFileUploadRequest` to support exclusive operations: I may want to upload a file "no matter what", overwriting the destination - which is the current behavior. Or I may want to atomically check-and-upload, which is the scope of this new flag. Both actions are legitimate and should be supported.

The PR proposes a minimal extension of the protocol. May we need to support other POSIX(-like) flags and have rather an enum instead of just a bool? I guess by now we're settled, yet for reference the years-old `open()` call has [plenty of options](https://www.man7.org/linux/man-pages/man2/open.2.html).

Related to this, there's been quite some discussion around locking within ownCloud, that's why I'm involving @butonic too. 

Comments/opinions welcome of course, but I'd like to move forward so to start testing the WOPI server locking logic with oCIS.