### PR TITLE
Add token scope field to gateway authenticate requests

### DIFF
--- a/cs3/auth/provider/v1beta1/provider_api.proto
+++ b/cs3/auth/provider/v1beta1/provider_api.proto
@@ -28,6 +28,7 @@ option java_package = "com.cs3.auth.provider.v1beta1";
 option objc_class_prefix = "CAP";
 option php_namespace = "Cs3\\Auth\\Provider\\V1Beta1";
 
+import "cs3/auth/provider/v1beta1/resources.proto";
 import "cs3/identity/user/v1beta1/resources.proto";
 import "cs3/rpc/v1beta1/status.proto";
 import "cs3/types/v1beta1/types.proto";
@@ -61,4 +62,8 @@ message AuthenticateRequest {
 message AuthenticateResponse {
   cs3.rpc.v1beta1.Status status = 1;
   cs3.identity.user.v1beta1.User user = 2;
+  // REQUIRED.
+  // The scope of the token to be issued.
+  // This would be a list of resources with corresponding role-based access scope.
+  map<string, Scope> token_scope = 3;
 }

--- a/cs3/auth/provider/v1beta1/resources.proto
+++ b/cs3/auth/provider/v1beta1/resources.proto
@@ -1,0 +1,62 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+syntax = "proto3";
+
+package cs3.auth.provider.v1beta1;
+
+option csharp_namespace = "Cs3.Auth.Provider.V1Beta1";
+option go_package = "providerv1beta1";
+option java_multiple_files = true;
+option java_outer_classname = "ResourcesProto";
+option java_package = "com.cs3.auth.provider.v1beta1";
+option objc_class_prefix = "CAP";
+option php_namespace = "Cs3\\Auth\\Provider\\V1Beta1";
+
+import "cs3/types/v1beta1/types.proto";
+
+// Scope defines role-based permissions for various resources.
+message Scope {
+  // REQUIRED.
+  // The resource embedded in the request of a particular method. It depends on
+  // the method, hence is left as opaque.
+  cs3.types.v1beta1.OpaqueEntry resource = 1;
+  // REQUIRED.
+  // The role associated with the resource.
+  Role role = 2;
+}
+
+// The role associated with the scope.
+enum Role {
+  // Used for invalid roles
+  ROLE_INVALID = 0;
+  // Grants owner permissions on a resource
+  ROLE_OWNER = 1;
+  // Provides backwards compatibility
+  ROLE_LEGACY = 2;
+  // Grants non-editor role on a resource
+  ROLE_VIEWER = 3;
+  // Grants editor permission on a resource, including folders
+  ROLE_EDITOR = 4;
+  // Grants editor permission on a single file
+  ROLE_FILE_EDITOR = 5;
+  // Grants co-owner permissions on a resource
+  ROLE_COOWNER = 6;
+  // Role with only write permission can use InitiateFileUpload, nothing else
+  ROLE_UPLOADER = 7;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -593,12 +593,35 @@
                   <a href="#cs3.auth.provider.v1beta1.AuthenticateResponse"><span class="badge">M</span>AuthenticateResponse</a>
                 </li>
               
+                <li>
+                  <a href="#cs3.auth.provider.v1beta1.AuthenticateResponse.TokenScopeEntry"><span class="badge">M</span>AuthenticateResponse.TokenScopeEntry</a>
+                </li>
+              
               
               
               
                 <li>
                   <a href="#cs3.auth.provider.v1beta1.ProviderAPI"><span class="badge">S</span>ProviderAPI</a>
                 </li>
+              
+            </ul>
+          </li>
+        
+          
+          <li>
+            <a href="#cs3%2fauth%2fprovider%2fv1beta1%2fresources.proto">cs3/auth/provider/v1beta1/resources.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#cs3.auth.provider.v1beta1.Scope"><span class="badge">M</span>Scope</a>
+                </li>
+              
+              
+                <li>
+                  <a href="#cs3.auth.provider.v1beta1.Role"><span class="badge">E</span>Role</a>
+                </li>
+              
+              
               
             </ul>
           </li>
@@ -5467,6 +5490,46 @@ by humans. </p></td>
                   <td><p> </p></td>
                 </tr>
               
+                <tr>
+                  <td>token_scope</td>
+                  <td><a href="#cs3.auth.provider.v1beta1.AuthenticateResponse.TokenScopeEntry">AuthenticateResponse.TokenScopeEntry</a></td>
+                  <td>repeated</td>
+                  <td><p>REQUIRED.
+The scope of the token to be issued.
+This would be a list of resources with corresponding role-based access scope. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.auth.provider.v1beta1.AuthenticateResponse.TokenScopeEntry">AuthenticateResponse.TokenScopeEntry</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>key</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#cs3.auth.provider.v1beta1.Scope">Scope</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -5499,6 +5562,113 @@ by humans. </p></td>
         </table>
 
         
+    
+      
+      <div class="file-heading">
+        <h2 id="cs3/auth/provider/v1beta1/resources.proto">cs3/auth/provider/v1beta1/resources.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="cs3.auth.provider.v1beta1.Scope">Scope</h3>
+        <p>Scope defines role-based permissions for various resources.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>resource</td>
+                  <td><a href="#cs3.types.v1beta1.OpaqueEntry">cs3.types.v1beta1.OpaqueEntry</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The resource embedded in the request of a particular method. It depends on
+the method, hence is left as opaque. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>role</td>
+                  <td><a href="#cs3.auth.provider.v1beta1.Role">Role</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The role associated with the resource. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+        <h3 id="cs3.auth.provider.v1beta1.Role">Role</h3>
+        <p>The role associated with the scope.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>ROLE_INVALID</td>
+                <td>0</td>
+                <td><p>Used for invalid roles</p></td>
+              </tr>
+            
+              <tr>
+                <td>ROLE_OWNER</td>
+                <td>1</td>
+                <td><p>Grants owner permissions on a resource</p></td>
+              </tr>
+            
+              <tr>
+                <td>ROLE_LEGACY</td>
+                <td>2</td>
+                <td><p>Provides backwards compatibility</p></td>
+              </tr>
+            
+              <tr>
+                <td>ROLE_VIEWER</td>
+                <td>3</td>
+                <td><p>Grants non-editor role on a resource</p></td>
+              </tr>
+            
+              <tr>
+                <td>ROLE_EDITOR</td>
+                <td>4</td>
+                <td><p>Grants editor permission on a resource, including folders</p></td>
+              </tr>
+            
+              <tr>
+                <td>ROLE_FILE_EDITOR</td>
+                <td>5</td>
+                <td><p>Grants editor permission on a single file</p></td>
+              </tr>
+            
+              <tr>
+                <td>ROLE_COOWNER</td>
+                <td>6</td>
+                <td><p>Grants co-owner permissions on a resource</p></td>
+              </tr>
+            
+              <tr>
+                <td>ROLE_UPLOADER</td>
+                <td>7</td>
+                <td><p>Role with only write permission can use InitiateFileUpload, nothing else</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+
+      
+
+      
     
       
       <div class="file-heading">


### PR DESCRIPTION
We mint the JWT tokens in Gateway/Authenticate. Adding an optional `token_scope` field would allow us to ensure that access is restricted to only these scopes. To be used in cases when we impersonate other users, including public shares, OCM shares and guest accounts.