### PR TITLE
update share api

### DIFF
--- a/cs3/sharing/collaboration/v1beta1/collaboration_api.proto
+++ b/cs3/sharing/collaboration/v1beta1/collaboration_api.proto
@@ -134,6 +134,9 @@ message UpdateShareResponse {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The updated share.
+  Share share = 3;
 }
 
 message ListSharesRequest {
@@ -261,6 +264,9 @@ message UpdateReceivedShareResponse {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The updated share.
+  ReceivedShare share = 3;
 }
 
 message GetReceivedShareRequest {

--- a/docs/index.html
+++ b/docs/index.html
@@ -8710,6 +8710,14 @@ The response status. </p></td>
 Opaque information. </p></td>
                 </tr>
               
+                <tr>
+                  <td>share</td>
+                  <td><a href="#cs3.sharing.collaboration.v1beta1.ReceivedShare">ReceivedShare</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The updated share. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -8813,6 +8821,14 @@ The response status. </p></td>
                   <td></td>
                   <td><p>OPTIONAL.
 Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>share</td>
+                  <td><a href="#cs3.sharing.collaboration.v1beta1.Share">Share</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The updated share. </p></td>
                 </tr>
               
             </tbody>


### PR DESCRIPTION
Added the updated share to the UpdateShareResponse so that we don't have to do 2 requests to update and return the updated share.

This is similar to the CreateShareResponse.