### PR TITLE
Extend app registry with methods to add providers and mimetype filters

### DIFF
--- a/cs3/app/provider/v1beta1/provider_api.proto
+++ b/cs3/app/provider/v1beta1/provider_api.proto
@@ -89,12 +89,6 @@ message OpenInAppRequest {
   // The access token MUST be short-lived.
   // TODO(labkode): investigate token derivation techniques.
   string access_token = 4;
-  // OPTIONAL.
-  // A reference to the application to be used to open the resource, should the
-  // default inferred from the resource's mimetype be overridden by user's choice.
-  // If the targeted resource is a directory, this parameter is required and
-  // in its absence the implementation MUST return INVALID_ARGUMENT.
-  string app = 5;
 }
 
 message OpenInAppResponse {

--- a/cs3/app/registry/v1beta1/registry_api.proto
+++ b/cs3/app/registry/v1beta1/registry_api.proto
@@ -106,15 +106,6 @@ message ListAppProvidersRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  // Represents a filter to apply to the request.
-  message Filter {
-    // if present, the response MUST list all known app providers for the given mimetype.
-    string mime_type = 1;
-  }
-  // OPTIONAL.
-  // The list of filters to apply if any.
-  repeated Filter filters = 2;
 }
 
 message ListAppProvidersResponse {

--- a/cs3/app/registry/v1beta1/registry_api.proto
+++ b/cs3/app/registry/v1beta1/registry_api.proto
@@ -53,8 +53,14 @@ service RegistryAPI {
   // Returns the app providers that are capable of handling this resource info.
   // MUST return CODE_NOT_FOUND if no providers are available.
   rpc GetAppProviders(GetAppProvidersRequest) returns (GetAppProvidersResponse);
+  // Registers a new app provider to the registry.
+  rpc AddAppProvider(AddAppProviderRequest) returns (AddAppProviderResponse);
   // Returns a list of the available app providers known by this registry.
   rpc ListAppProviders(ListAppProvidersRequest) returns (ListAppProvidersResponse);
+  // Returns the default app provider which serves a specified mime type.
+  rpc GetDefaultAppProviderForMimeType(GetDefaultAppProviderForMimeTypeRequest) returns (GetDefaultAppProviderForMimeTypeResponse);
+  // Sets the default app provider for a specified mime type.
+  rpc SetDefaultAppProviderForMimeType(SetDefaultAppProviderForMimeTypeRequest) returns (SetDefaultAppProviderForMimeTypeResponse);
 }
 
 message GetAppProvidersRequest {
@@ -78,6 +84,24 @@ message GetAppProvidersResponse {
   repeated ProviderInfo providers = 3;
 }
 
+message AddAppProviderRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The app provider to be registered.
+  ProviderInfo provider = 2;
+}
+
+message AddAppProviderResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+}
+
 message ListAppProvidersRequest {
   // OPTIONAL.
   // Opaque information.
@@ -85,17 +109,8 @@ message ListAppProvidersRequest {
   // REQUIRED.
   // Represents a filter to apply to the request.
   message Filter {
-    // The filter to apply.
-    enum Type {
-      TYPE_INVALID = 0;
-      TYPE_MIME_TYPE = 1;
-    }
-    // REQUIRED.
-    Type type = 2;
-    oneof term {
-      // if present, the response MUST list all known app providers for the given mimetype.
-      string mime_type = 3;
-    }
+    // if present, the response MUST list all known app providers for the given mimetype.
+    string mime_type = 1;
   }
   // OPTIONAL.
   // The list of filters to apply if any.
@@ -112,4 +127,46 @@ message ListAppProvidersResponse {
   // REQUIRED.
   // The list of app providers this registry knows about.
   repeated ProviderInfo providers = 3;
+}
+
+message GetDefaultAppProviderForMimeTypeRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The mimetype for which the default app has to be returned.
+  string mime_type = 2;
+}
+
+message GetDefaultAppProviderForMimeTypeResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The default app provider for the specified mime type.
+  ProviderInfo provider = 3;
+}
+
+message SetDefaultAppProviderForMimeTypeRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The mimetype for which the default app has to be returned.
+  string mime_type = 2;
+  // REQUIRED.
+  // The app provider to be marked as default for the specified mime type.
+  ProviderInfo provider = 3;
+}
+
+message SetDefaultAppProviderForMimeTypeResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
 }

--- a/cs3/app/registry/v1beta1/resources.proto
+++ b/cs3/app/registry/v1beta1/resources.proto
@@ -43,8 +43,11 @@ message ProviderInfo {
   // For example, tcp://localhost:1099.
   string address = 3;
   // OPTIONAL.
+  // A human-readable name of the app provider.
+  string name = 4;
+  // OPTIONAL.
   // Information to describe the functionalities
   // offered by the app provider. Meant to be read
   // by humans.
-  string description = 4;
+  string description = 5;
 }

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -550,8 +550,10 @@ message OpenInAppRequest {
   }
   ViewMode view_mode = 3;
   // OPTIONAL.
-  // The application to be used to open the resource. Defaults to the primary application
-  // registered for the mime type of the given resource.
+  // A reference to the application to be used to open the resource, should the
+  // default inferred from the resource's mimetype be overridden by user's choice.
+  // If the targeted resource is a directory, this parameter is required and
+  // in its absence the implementation MUST return INVALID_ARGUMENT.
   string app = 4;
 }
 

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -287,8 +287,14 @@ service GatewayAPI {
   // Returns the app providers that are capable of handling this resource info.
   // MUST return CODE_NOT_FOUND if no providers are available.
   rpc GetAppProviders(cs3.app.registry.v1beta1.GetAppProvidersRequest) returns (cs3.app.registry.v1beta1.GetAppProvidersResponse);
+  // Registers a new app provider to the registry.
+  rpc AddAppProvider(cs3.app.registry.v1beta1.AddAppProviderRequest) returns (cs3.app.registry.v1beta1.AddAppProviderResponse);
   // Returns a list of the available app providers known by this registry.
   rpc ListAppProviders(cs3.app.registry.v1beta1.ListAppProvidersRequest) returns (cs3.app.registry.v1beta1.ListAppProvidersResponse);
+  // Returns the default app provider which serves a specified mime type.
+  rpc GetDefaultAppProviderForMimeType(cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeRequest) returns (cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeResponse);
+  // Sets the default app provider for a specified mime type.
+  rpc SetDefaultAppProviderForMimeType(cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest) returns (cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeResponse);
   // *****************************************************************/
   // ************************ USER PROVIDER **************************/
   // *****************************************************************/

--- a/docs/index.html
+++ b/docs/index.html
@@ -2362,8 +2362,10 @@ when a call to the WOPI server is to be issued (cf. the provider grpc message) <
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-The application to be used to open the resource. Defaults to the primary application
-registered for the mime type of the given resource. </p></td>
+A reference to the application to be used to open the resource, should the
+default inferred from the resource&#39;s mimetype be overridden by user&#39;s choice.
+If the targeted resource is a directory, this parameter is required and
+in its absence the implementation MUST return INVALID_ARGUMENT. </p></td>
                 </tr>
               
             </tbody>
@@ -5185,17 +5187,6 @@ Service implementors should use a ResourceId rather than a filepath to grant acc
 ResourceIds MUST NOT change when a resource is renamed.
 The access token MUST be short-lived.
 TODO(labkode): investigate token derivation techniques. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>app</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-A reference to the application to be used to open the resource, should the
-default inferred from the resource&#39;s mimetype be overridden by user&#39;s choice.
-If the targeted resource is a directory, this parameter is required and
-in its absence the implementation MUST return INVALID_ARGUMENT. </p></td>
                 </tr>
               
             </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -568,10 +568,6 @@
                 </li>
               
                 <li>
-                  <a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter"><span class="badge">M</span>ListAppProvidersRequest.Filter</a>
-                </li>
-              
-                <li>
                   <a href="#cs3.app.registry.v1beta1.ListAppProvidersResponse"><span class="badge">M</span>ListAppProvidersResponse</a>
                 </li>
               
@@ -5593,38 +5589,6 @@ The default app provider for the specified mime type. </p></td>
                   <td></td>
                   <td><p>OPTIONAL.
 Opaque information. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>filters</td>
-                  <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter">ListAppProvidersRequest.Filter</a></td>
-                  <td>repeated</td>
-                  <td><p>OPTIONAL.
-The list of filters to apply if any. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
-        <h3 id="cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter">ListAppProvidersRequest.Filter</h3>
-        <p>REQUIRED.</p><p>Represents a filter to apply to the request.</p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>mime_type</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>if present, the response MUST list all known app providers for the given mimetype. </p></td>
                 </tr>
               
             </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -540,11 +540,27 @@
             <ul>
               
                 <li>
+                  <a href="#cs3.app.registry.v1beta1.AddAppProviderRequest"><span class="badge">M</span>AddAppProviderRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.app.registry.v1beta1.AddAppProviderResponse"><span class="badge">M</span>AddAppProviderResponse</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.app.registry.v1beta1.GetAppProvidersRequest"><span class="badge">M</span>GetAppProvidersRequest</a>
                 </li>
               
                 <li>
                   <a href="#cs3.app.registry.v1beta1.GetAppProvidersResponse"><span class="badge">M</span>GetAppProvidersResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeRequest"><span class="badge">M</span>GetDefaultAppProviderForMimeTypeRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeResponse"><span class="badge">M</span>GetDefaultAppProviderForMimeTypeResponse</a>
                 </li>
               
                 <li>
@@ -559,10 +575,14 @@
                   <a href="#cs3.app.registry.v1beta1.ListAppProvidersResponse"><span class="badge">M</span>ListAppProvidersResponse</a>
                 </li>
               
+                <li>
+                  <a href="#cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest"><span class="badge">M</span>SetDefaultAppProviderForMimeTypeRequest</a>
+                </li>
               
                 <li>
-                  <a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter.Type"><span class="badge">E</span>ListAppProvidersRequest.Filter.Type</a>
+                  <a href="#cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeResponse"><span class="badge">M</span>SetDefaultAppProviderForMimeTypeResponse</a>
                 </li>
+              
               
               
               
@@ -3050,10 +3070,31 @@ MUST return CODE_NOT_FOUND if no providers are available.</p></td>
               </tr>
             
               <tr>
+                <td>AddAppProvider</td>
+                <td><a href="#cs3.app.registry.v1beta1.AddAppProviderRequest">.cs3.app.registry.v1beta1.AddAppProviderRequest</a></td>
+                <td><a href="#cs3.app.registry.v1beta1.AddAppProviderResponse">.cs3.app.registry.v1beta1.AddAppProviderResponse</a></td>
+                <td><p>Registers a new app provider to the registry.</p></td>
+              </tr>
+            
+              <tr>
                 <td>ListAppProviders</td>
                 <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest">.cs3.app.registry.v1beta1.ListAppProvidersRequest</a></td>
                 <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersResponse">.cs3.app.registry.v1beta1.ListAppProvidersResponse</a></td>
-                <td><p>Returns a list of the available app providers known by this registry.
+                <td><p>Returns a list of the available app providers known by this registry.</p></td>
+              </tr>
+            
+              <tr>
+                <td>GetDefaultAppProviderForMimeType</td>
+                <td><a href="#cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeRequest">.cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeRequest</a></td>
+                <td><a href="#cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeResponse">.cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeResponse</a></td>
+                <td><p>Returns the default app provider which serves a specified mime type.</p></td>
+              </tr>
+            
+              <tr>
+                <td>SetDefaultAppProviderForMimeType</td>
+                <td><a href="#cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest">.cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest</a></td>
+                <td><a href="#cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeResponse">.cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeResponse</a></td>
+                <td><p>Sets the default app provider for a specified mime type.
 
 *****************************************************************/
 ************************ USER PROVIDER **************************/
@@ -5322,6 +5363,72 @@ MUST return CODE_NOT_FOUND if the resource does not exist.</p></td>
       <p></p>
 
       
+        <h3 id="cs3.app.registry.v1beta1.AddAppProviderRequest">AddAppProviderRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>provider</td>
+                  <td><a href="#cs3.app.registry.v1beta1.ProviderInfo">ProviderInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The app provider to be registered. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.app.registry.v1beta1.AddAppProviderResponse">AddAppProviderResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.app.registry.v1beta1.GetAppProvidersRequest">GetAppProvidersRequest</h3>
         <p></p>
 
@@ -5396,6 +5503,80 @@ The app providers available for the given resource info. </p></td>
 
         
       
+        <h3 id="cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeRequest">GetDefaultAppProviderForMimeTypeRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>mime_type</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The mimetype for which the default app has to be returned. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeResponse">GetDefaultAppProviderForMimeTypeResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>provider</td>
+                  <td><a href="#cs3.app.registry.v1beta1.ProviderInfo">ProviderInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The default app provider for the specified mime type. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.app.registry.v1beta1.ListAppProvidersRequest">ListAppProvidersRequest</h3>
         <p></p>
 
@@ -5438,13 +5619,6 @@ The list of filters to apply if any. </p></td>
               <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
             </thead>
             <tbody>
-              
-                <tr>
-                  <td>type</td>
-                  <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter.Type">ListAppProvidersRequest.Filter.Type</a></td>
-                  <td></td>
-                  <td><p>REQUIRED. </p></td>
-                </tr>
               
                 <tr>
                   <td>mime_type</td>
@@ -5501,30 +5675,81 @@ The list of app providers this registry knows about. </p></td>
 
         
       
+        <h3 id="cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest">SetDefaultAppProviderForMimeTypeRequest</h3>
+        <p></p>
 
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>mime_type</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The mimetype for which the default app has to be returned. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>provider</td>
+                  <td><a href="#cs3.app.registry.v1beta1.ProviderInfo">ProviderInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The app provider to be marked as default for the specified mime type. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
       
-        <h3 id="cs3.app.registry.v1beta1.ListAppProvidersRequest.Filter.Type">ListAppProvidersRequest.Filter.Type</h3>
-        <p>The filter to apply.</p>
-        <table class="enum-table">
-          <thead>
-            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
-          </thead>
-          <tbody>
-            
-              <tr>
-                <td>TYPE_INVALID</td>
-                <td>0</td>
-                <td><p></p></td>
-              </tr>
-            
-              <tr>
-                <td>TYPE_MIME_TYPE</td>
-                <td>1</td>
-                <td><p></p></td>
-              </tr>
-            
-          </tbody>
-        </table>
+        <h3 id="cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeResponse">SetDefaultAppProviderForMimeTypeResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
       
 
       
@@ -5547,10 +5772,31 @@ MUST return CODE_NOT_FOUND if no providers are available.</p></td>
               </tr>
             
               <tr>
+                <td>AddAppProvider</td>
+                <td><a href="#cs3.app.registry.v1beta1.AddAppProviderRequest">AddAppProviderRequest</a></td>
+                <td><a href="#cs3.app.registry.v1beta1.AddAppProviderResponse">AddAppProviderResponse</a></td>
+                <td><p>Registers a new app provider to the registry.</p></td>
+              </tr>
+            
+              <tr>
                 <td>ListAppProviders</td>
                 <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersRequest">ListAppProvidersRequest</a></td>
                 <td><a href="#cs3.app.registry.v1beta1.ListAppProvidersResponse">ListAppProvidersResponse</a></td>
                 <td><p>Returns a list of the available app providers known by this registry.</p></td>
+              </tr>
+            
+              <tr>
+                <td>GetDefaultAppProviderForMimeType</td>
+                <td><a href="#cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeRequest">GetDefaultAppProviderForMimeTypeRequest</a></td>
+                <td><a href="#cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeResponse">GetDefaultAppProviderForMimeTypeResponse</a></td>
+                <td><p>Returns the default app provider which serves a specified mime type.</p></td>
+              </tr>
+            
+              <tr>
+                <td>SetDefaultAppProviderForMimeType</td>
+                <td><a href="#cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest">SetDefaultAppProviderForMimeTypeRequest</a></td>
+                <td><a href="#cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeResponse">SetDefaultAppProviderForMimeTypeResponse</a></td>
+                <td><p>Sets the default app provider for a specified mime type.</p></td>
               </tr>
             
           </tbody>
@@ -5598,6 +5844,14 @@ The mimetypes handled by this provider. </p></td>
                   <td><p>REQUIRED.
 The address where the app provider can be reached.
 For example, tcp://localhost:1099. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A human-readable name of the app provider. </p></td>
                 </tr>
               
                 <tr>

--- a/proto.lock
+++ b/proto.lock
@@ -557,20 +557,6 @@
     {
       "protopath": "cs3:/:app:/:registry:/:v1beta1:/:registry_api.proto",
       "def": {
-        "enums": [
-          {
-            "name": "Filter.Type",
-            "enum_fields": [
-              {
-                "name": "TYPE_INVALID"
-              },
-              {
-                "name": "TYPE_MIME_TYPE",
-                "integer": 1
-              }
-            ]
-          }
-        ],
         "messages": [
           {
             "name": "GetAppProvidersRequest",
@@ -609,6 +595,36 @@
             ]
           },
           {
+            "name": "AddAppProviderRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "provider",
+                "type": "ProviderInfo"
+              }
+            ]
+          },
+          {
+            "name": "AddAppProviderResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
             "name": "ListAppProvidersRequest",
             "fields": [
               {
@@ -628,12 +644,7 @@
                 "name": "Filter",
                 "fields": [
                   {
-                    "id": 2,
-                    "name": "type",
-                    "type": "Type"
-                  },
-                  {
-                    "id": 3,
+                    "id": 1,
                     "name": "mime_type",
                     "type": "string"
                   }
@@ -661,6 +672,76 @@
                 "is_repeated": true
               }
             ]
+          },
+          {
+            "name": "GetDefaultAppProviderForMimeTypeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "mime_type",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetDefaultAppProviderForMimeTypeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "provider",
+                "type": "ProviderInfo"
+              }
+            ]
+          },
+          {
+            "name": "SetDefaultAppProviderForMimeTypeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "mime_type",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "provider",
+                "type": "ProviderInfo"
+              }
+            ]
+          },
+          {
+            "name": "SetDefaultAppProviderForMimeTypeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
           }
         ],
         "services": [
@@ -673,9 +754,24 @@
                 "out_type": "GetAppProvidersResponse"
               },
               {
+                "name": "AddAppProvider",
+                "in_type": "AddAppProviderRequest",
+                "out_type": "AddAppProviderResponse"
+              },
+              {
                 "name": "ListAppProviders",
                 "in_type": "ListAppProvidersRequest",
                 "out_type": "ListAppProvidersResponse"
+              },
+              {
+                "name": "GetDefaultAppProviderForMimeType",
+                "in_type": "GetDefaultAppProviderForMimeTypeRequest",
+                "out_type": "GetDefaultAppProviderForMimeTypeResponse"
+              },
+              {
+                "name": "SetDefaultAppProviderForMimeType",
+                "in_type": "SetDefaultAppProviderForMimeTypeRequest",
+                "out_type": "SetDefaultAppProviderForMimeTypeResponse"
               }
             ]
           }
@@ -754,6 +850,11 @@
               },
               {
                 "id": 4,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 5,
                 "name": "description",
                 "type": "string"
               }
@@ -2156,9 +2257,24 @@
                 "out_type": "cs3.app.registry.v1beta1.GetAppProvidersResponse"
               },
               {
+                "name": "AddAppProvider",
+                "in_type": "cs3.app.registry.v1beta1.AddAppProviderRequest",
+                "out_type": "cs3.app.registry.v1beta1.AddAppProviderResponse"
+              },
+              {
                 "name": "ListAppProviders",
                 "in_type": "cs3.app.registry.v1beta1.ListAppProvidersRequest",
                 "out_type": "cs3.app.registry.v1beta1.ListAppProvidersResponse"
+              },
+              {
+                "name": "GetDefaultAppProviderForMimeType",
+                "in_type": "cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeRequest",
+                "out_type": "cs3.app.registry.v1beta1.GetDefaultAppProviderForMimeTypeResponse"
+              },
+              {
+                "name": "SetDefaultAppProviderForMimeType",
+                "in_type": "cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest",
+                "out_type": "cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeResponse"
               },
               {
                 "name": "GetUser",

--- a/proto.lock
+++ b/proto.lock
@@ -631,24 +631,6 @@
                 "id": 1,
                 "name": "opaque",
                 "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "filters",
-                "type": "Filter",
-                "is_repeated": true
-              }
-            ],
-            "messages": [
-              {
-                "name": "Filter",
-                "fields": [
-                  {
-                    "id": 1,
-                    "name": "mime_type",
-                    "type": "string"
-                  }
-                ]
               }
             ]
           },

--- a/proto.lock
+++ b/proto.lock
@@ -417,11 +417,6 @@
                 "id": 4,
                 "name": "access_token",
                 "type": "string"
-              },
-              {
-                "id": 5,
-                "name": "app",
-                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
This PR adds methods to register new app providers on the fly and to set and retrieve default app providers for mime types. It has a change that might break the clients using the current version. We remove the mime type filters from `ListAppProvidersRequest` as that is redundant and performs the same functionality as `GetAppProvidersRequest`.