### PR TITLE
Documentation fixes

### DIFF
--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -284,14 +284,14 @@ message InitiateFileUploadRequest {
     // OPTIONAL.
     // Whether the file is to be uploaded in exclusive mode. Defaults to false.
     // If true, the request SHALL be processed such that only one of multiple concurrent uploads
-    // to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
+    // to the same target reference MAY succeed, whereas all others MUST fail with CODE_FAILED_PRECONDITION.
     // The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
     // The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode.
     bool if_not_exist = 3;
     // OPTIONAL.
     // Whether the file is to be uploaded if the given etag matches. Default to always upload.
-    // If a mismatching etag is given, the request MUST return CODE_ALREADY_EXISTS with the current etag
-    // in the opaque field.
+    // If the storage provider has a more recent etag for the target file, the request MUST
+    // return CODE_FAILED_PRECONDITION.
     string if_match = 4;
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -12595,28 +12595,6 @@ Opaque information. </p></td>
 The reference to which the action should be performed. </p></td>
                 </tr>
               
-                <tr>
-                  <td>if_not_exist</td>
-                  <td><a href="#bool">bool</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Whether the file is to be uploaded in exclusive mode. Defaults to false.
-If true, the request SHALL be processed such that only one of multiple concurrent uploads
-to the same target reference MAY succeed, whereas all others MUST fail with CODE_ALREADY_EXISTS.
-The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
-The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>if_match</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Whether the file is to be uploaded if the given etag matches. Default to always upload.
-If a mismatching etag is given, the request MUST return CODE_ALREADY_EXISTS with the current etag
-in the opaque field. </p></td>
-                </tr>
-              
             </tbody>
           </table>
 
@@ -13403,6 +13381,28 @@ Opaque information. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The reference to which the action should be performed. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>if_not_exist</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Whether the file is to be uploaded in exclusive mode. Defaults to false.
+If true, the request SHALL be processed such that only one of multiple concurrent uploads
+to the same target reference MAY succeed, whereas all others MUST fail with CODE_FAILED_PRECONDITION.
+The semantic is similar to the O_CREAT|O_EXCL POSIX flags.
+The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support this mode. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>if_match</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Whether the file is to be uploaded if the given etag matches. Default to always upload.
+If the storage provider has a more recent etag for the target file, the request MUST
+return CODE_FAILED_PRECONDITION. </p></td>
                 </tr>
               
             </tbody>


### PR DESCRIPTION
Following #122, specifications are better spelled out now.