### PR TITLE
New method PullTransfer.

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -365,12 +365,16 @@ service GatewayAPI {
   // ************************** FILE TRANSFER ************************/
   // *****************************************************************/
 
-  // Returns a response containing a TxInfo (transfer info) object.
-  rpc CreateTransfer(cs3.tx.v1beta1.CreateTransferRequest) returns (cs3.tx.v1beta1.CreateTransferResponse);
+  //  Requests the destination to pull a resource from source.
+  rpc PullTransfer(cs3.tx.v1beta1.PullTransferRequest) returns (cs3.tx.v1beta1.PullTransferResponse);
   // Requests a transfer status.
   rpc GetTransferStatus(cs3.tx.v1beta1.GetTransferStatusRequest) returns (cs3.tx.v1beta1.GetTransferStatusResponse);
   // Requests to cancel a transfer.
   rpc CancelTransfer(cs3.tx.v1beta1.CancelTransferRequest) returns (cs3.tx.v1beta1.CancelTransferResponse);
+  // Requests a list of transfers received by the authenticated principle.
+  rpc ListTransfers(cs3.tx.v1beta1.ListTransfersRequest) returns (cs3.tx.v1beta1.ListTransfersResponse);
+  // Requests retrying a transfer.
+  rpc RetryTransfer(cs3.tx.v1beta1.RetryTransferRequest) returns (cs3.tx.v1beta1.RetryTransferResponse);
 }
 
 // CAUTION:

--- a/cs3/tx/v1beta1/resources.proto
+++ b/cs3/tx/v1beta1/resources.proto
@@ -47,48 +47,46 @@ message TxInfo {
   // The transfer identifier.
   TxId id = 1;
   // REQUIRED.
-  // Reference of the resource to be transfered.
-  cs3.storage.provider.v1beta1.Reference ref = 2;
-  // Status represents transfer status.
-  enum Status {
-    STATUS_INVALID = 0;
-    // The destination could not be found.
-    STATUS_DESTINATION_NOT_FOUND = 1;
-    // A new data transfer
-    STATUS_TRANSFER_NEW = 2;
-    // The data transfer is awaiting acceptance from the destination
-    STATUS_TRANSFER_AWAITING_ACCEPTANCE = 3;
-    // The data transfer is accepted by the destination.
-    STATUS_TRANSFER_ACCEPTED = 4;
-    // The data transfer has started and not yet completed.
-    STATUS_TRANSFER_IN_PROGRESS = 5;
-    // The data transfer has completed.
-    STATUS_TRANSFER_COMPLETE = 6;
-    // The data transfer has failed.
-    STATUS_TRANSFER_FAILED = 7;
-    // The data transfer had been cancelled.
-    STATUS_TRANSFER_CANCELLED = 8;
-    // The request for cancelling the data transfer has failed.
-    STATUS_TRANSFER_CANCEL_FAILED = 9;
-    // The transfer has expired somewhere down the line.
-    STATUS_TRANSFER_EXPIRED = 10;
-  }
-  // REQUIRED.
   // The transfer status. Eg.: STATUS_TRANSFER_FAILED.
   // Note: the description field may provide additional information on the transfer status.
-  Status status = 3;
+  Status status = 2;
   // REQUIRED.
   // The destination (receiver of the transfer)
-  cs3.storage.provider.v1beta1.Grantee grantee = 4;
+  cs3.storage.provider.v1beta1.Grantee grantee = 3;
   // REQUIRED.
   // Uniquely identifies a principal who initiates the transfer creation.
-  cs3.identity.user.v1beta1.UserId creator = 5;
+  cs3.identity.user.v1beta1.UserId creator = 4;
   // REQUIRED.
   // Creation time of the transfer.
-  cs3.types.v1beta1.Timestamp ctime = 6;
+  cs3.types.v1beta1.Timestamp ctime = 5;
   // OPTIONAL.
   // Information to describe the transfer status.
   // Eg. may contain information about a transfer failure.
   // Meant to be human-readable.
-  string description = 7;
+  string description = 6;
+}
+
+// Status represents transfer status.
+enum Status {
+  STATUS_INVALID = 0;
+  // The destination could not be found.
+  STATUS_DESTINATION_NOT_FOUND = 1;
+  // A new data transfer
+  STATUS_TRANSFER_NEW = 2;
+  // The data transfer is awaiting acceptance from the destination
+  STATUS_TRANSFER_AWAITING_ACCEPTANCE = 3;
+  // The data transfer is accepted by the destination.
+  STATUS_TRANSFER_ACCEPTED = 4;
+  // The data transfer has started and not yet completed.
+  STATUS_TRANSFER_IN_PROGRESS = 5;
+  // The data transfer has completed.
+  STATUS_TRANSFER_COMPLETE = 6;
+  // The data transfer has failed.
+  STATUS_TRANSFER_FAILED = 7;
+  // The data transfer had been cancelled.
+  STATUS_TRANSFER_CANCELLED = 8;
+  // The request for cancelling the data transfer has failed.
+  STATUS_TRANSFER_CANCEL_FAILED = 9;
+  // The transfer has expired somewhere down the line.
+  STATUS_TRANSFER_EXPIRED = 10;
 }

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -29,6 +29,7 @@ option objc_class_prefix = "CTX";
 option php_namespace = "Cs3\\Tx\\V1Beta1";
 
 import "cs3/rpc/v1beta1/status.proto";
+import "cs3/sharing/collaboration/v1beta1/resources.proto";
 import "cs3/tx/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 
@@ -131,10 +132,23 @@ message ListTransfersRequest {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
-  // represents a filter to apply to the request.
+  // Represents a filter to apply to the request.
   message Filter {
+    // The filter type.
+    enum Type {
+      TYPE_INVALID = 0;
+      TYPE_STATUS = 1;
+      TYPE_SHARE_REF = 2;
+      TYPE_TX_ID = 3;
+    }
     // REQUIRED.
-    Status status = 1;
+    Type type = 1;
+    // REQUIRED.
+    oneof term {
+      Status status = 2;
+      cs3.sharing.collaboration.v1beta1.ShareReference share_ref = 3;
+      TxId tx_id = 4;
+    }
   }
   // OPTIONAL.
   // The list of filters to apply if any.

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -52,6 +52,9 @@ service TxAPI {
   // Creates (requests the destination to accept) a transfer.
   // Returns a response containing a TxInfo (transfer info) object.
   rpc CreateTransfer(CreateTransferRequest) returns (CreateTransferResponse);
+  // Requests the destination to pull a resource from source.
+  // Returns a PullTransferResponse
+  rpc PullTransfer(PullTransferRequest) returns (PullTransferResponse);
   // Requests a transfer status.
   rpc GetTransferStatus(GetTransferStatusRequest) returns (GetTransferStatusResponse);
   // Requests to cancel a transfer.
@@ -71,6 +74,31 @@ message CreateTransferRequest {
 }
 
 message CreateTransferResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // REQUIRED.
+  // TxInfo, includes transfer id, status, description.
+  TxInfo tx_info = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
+}
+
+message PullTransferRequest {
+  // REQUIRED.
+  // The target URI. Should include at the minimum all the info needed to access the source.
+  // https://golang.org/pkg/net/url/#URL provides a quick view of the format.
+  string target_uri = 1;
+  // OPTIONAL.
+  // The transfer identifier.
+  TxId tx_id = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
+}
+
+message PullTransferResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;

--- a/cs3/tx/v1beta1/tx_api.proto
+++ b/cs3/tx/v1beta1/tx_api.proto
@@ -29,7 +29,6 @@ option objc_class_prefix = "CTX";
 option php_namespace = "Cs3\\Tx\\V1Beta1";
 
 import "cs3/rpc/v1beta1/status.proto";
-import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/tx/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 
@@ -49,9 +48,6 @@ import "cs3/types/v1beta1/types.proto";
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
 service TxAPI {
-  // Creates (requests the destination to accept) a transfer.
-  // Returns a response containing a TxInfo (transfer info) object.
-  rpc CreateTransfer(CreateTransferRequest) returns (CreateTransferResponse);
   // Requests the destination to pull a resource from source.
   // Returns a PullTransferResponse
   rpc PullTransfer(PullTransferRequest) returns (PullTransferResponse);
@@ -59,30 +55,11 @@ service TxAPI {
   rpc GetTransferStatus(GetTransferStatusRequest) returns (GetTransferStatusResponse);
   // Requests to cancel a transfer.
   rpc CancelTransfer(CancelTransferRequest) returns (CancelTransferResponse);
-}
-
-message CreateTransferRequest {
-  // REQUIRED.
-  // Reference of the resource to be transfered.
-  cs3.storage.provider.v1beta1.Reference ref = 1;
-  // REQUIRED.
-  // The destination (receiver of the transfer)
-  cs3.storage.provider.v1beta1.Grantee grantee = 2;
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 3;
-}
-
-message CreateTransferResponse {
-  // REQUIRED.
-  // The response status.
-  cs3.rpc.v1beta1.Status status = 1;
-  // REQUIRED.
-  // TxInfo, includes transfer id, status, description.
-  TxInfo tx_info = 2;
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 3;
+  // Requests a list of transfers received by the authenticated principle.
+  // If a filter is specified, only transfers satisfying the filter MUST be returned.
+  rpc ListTransfers(ListTransfersRequest) returns (ListTransfersResponse);
+  // Requests retrying a transfer.
+  rpc RetryTransfer(RetryTransferRequest) returns (RetryTransferResponse);
 }
 
 message PullTransferRequest {
@@ -91,11 +68,8 @@ message PullTransferRequest {
   // https://golang.org/pkg/net/url/#URL provides a quick view of the format.
   string target_uri = 1;
   // OPTIONAL.
-  // The transfer identifier.
-  TxId tx_id = 2;
-  // OPTIONAL.
   // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 3;
+  cs3.types.v1beta1.Opaque opaque = 2;
 }
 
 message PullTransferResponse {
@@ -141,6 +115,54 @@ message CancelTransferRequest {
 }
 
 message CancelTransferResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // REQUIRED.
+  // TxInfo, includes ao. transfer id, status, description.
+  TxInfo tx_info = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
+}
+
+message ListTransfersRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // represents a filter to apply to the request.
+  message Filter {
+    // REQUIRED.
+    Status status = 1;
+  }
+  // OPTIONAL.
+  // The list of filters to apply if any.
+  repeated Filter filters = 2;
+}
+
+message ListTransfersResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // REQUIRED.
+  // List of TxInfo types representing transfers.
+  repeated TxInfo transfers = 2;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 3;
+}
+
+message RetryTransferRequest {
+  // REQUIRED.
+  // The transfer identifier.
+  TxId tx_id = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+}
+
+message RetryTransferResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;

--- a/docs/index.html
+++ b/docs/index.html
@@ -380,6 +380,14 @@
                   <a href="#cs3.tx.v1beta1.GetTransferStatusResponse"><span class="badge">M</span>GetTransferStatusResponse</a>
                 </li>
               
+                <li>
+                  <a href="#cs3.tx.v1beta1.PullTransferRequest"><span class="badge">M</span>PullTransferRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.PullTransferResponse"><span class="badge">M</span>PullTransferResponse</a>
+                </li>
+              
               
               
               
@@ -4295,6 +4303,89 @@ Opaque information. </p></td>
 
         
       
+        <h3 id="cs3.tx.v1beta1.PullTransferRequest">PullTransferRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>target_uri</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The target URI. Should include at the minimum all the info needed to access the source.
+https://golang.org/pkg/net/url/#URL provides a quick view of the format. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tx_id</td>
+                  <td><a href="#cs3.tx.v1beta1.TxId">TxId</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+The transfer identifier. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.PullTransferResponse">PullTransferResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tx_info</td>
+                  <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+TxInfo, includes transfer id, status, description. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
 
       
 
@@ -4315,6 +4406,14 @@ Opaque information. </p></td>
                 <td><a href="#cs3.tx.v1beta1.CreateTransferResponse">CreateTransferResponse</a></td>
                 <td><p>Creates (requests the destination to accept) a transfer.
 Returns a response containing a TxInfo (transfer info) object.</p></td>
+              </tr>
+            
+              <tr>
+                <td>PullTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.PullTransferRequest">PullTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.PullTransferResponse">PullTransferResponse</a></td>
+                <td><p>Requests the destination to pull a resource from source.
+Returns a PullTransferResponse</p></td>
               </tr>
             
               <tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -343,7 +343,7 @@
               
               
                 <li>
-                  <a href="#cs3.tx.v1beta1.TxInfo.Status"><span class="badge">E</span>TxInfo.Status</a>
+                  <a href="#cs3.tx.v1beta1.Status"><span class="badge">E</span>Status</a>
                 </li>
               
               
@@ -365,14 +365,6 @@
                 </li>
               
                 <li>
-                  <a href="#cs3.tx.v1beta1.CreateTransferRequest"><span class="badge">M</span>CreateTransferRequest</a>
-                </li>
-              
-                <li>
-                  <a href="#cs3.tx.v1beta1.CreateTransferResponse"><span class="badge">M</span>CreateTransferResponse</a>
-                </li>
-              
-                <li>
                   <a href="#cs3.tx.v1beta1.GetTransferStatusRequest"><span class="badge">M</span>GetTransferStatusRequest</a>
                 </li>
               
@@ -381,11 +373,31 @@
                 </li>
               
                 <li>
+                  <a href="#cs3.tx.v1beta1.ListTransfersRequest"><span class="badge">M</span>ListTransfersRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.ListTransfersRequest.Filter"><span class="badge">M</span>ListTransfersRequest.Filter</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.ListTransfersResponse"><span class="badge">M</span>ListTransfersResponse</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.tx.v1beta1.PullTransferRequest"><span class="badge">M</span>PullTransferRequest</a>
                 </li>
               
                 <li>
                   <a href="#cs3.tx.v1beta1.PullTransferResponse"><span class="badge">M</span>PullTransferResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.RetryTransferRequest"><span class="badge">M</span>RetryTransferRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.tx.v1beta1.RetryTransferResponse"><span class="badge">M</span>RetryTransferResponse</a>
                 </li>
               
               
@@ -3241,10 +3253,10 @@ MUST return CODE_NOT_FOUND if the sync&#39;n&#39;share system provider does not 
               </tr>
             
               <tr>
-                <td>CreateTransfer</td>
-                <td><a href="#cs3.tx.v1beta1.CreateTransferRequest">.cs3.tx.v1beta1.CreateTransferRequest</a></td>
-                <td><a href="#cs3.tx.v1beta1.CreateTransferResponse">.cs3.tx.v1beta1.CreateTransferResponse</a></td>
-                <td><p>Returns a response containing a TxInfo (transfer info) object.</p></td>
+                <td>PullTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.PullTransferRequest">.cs3.tx.v1beta1.PullTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.PullTransferResponse">.cs3.tx.v1beta1.PullTransferResponse</a></td>
+                <td><p>Requests the destination to pull a resource from source.</p></td>
               </tr>
             
               <tr>
@@ -3259,6 +3271,20 @@ MUST return CODE_NOT_FOUND if the sync&#39;n&#39;share system provider does not 
                 <td><a href="#cs3.tx.v1beta1.CancelTransferRequest">.cs3.tx.v1beta1.CancelTransferRequest</a></td>
                 <td><a href="#cs3.tx.v1beta1.CancelTransferResponse">.cs3.tx.v1beta1.CancelTransferResponse</a></td>
                 <td><p>Requests to cancel a transfer.</p></td>
+              </tr>
+            
+              <tr>
+                <td>ListTransfers</td>
+                <td><a href="#cs3.tx.v1beta1.ListTransfersRequest">.cs3.tx.v1beta1.ListTransfersRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.ListTransfersResponse">.cs3.tx.v1beta1.ListTransfersResponse</a></td>
+                <td><p>Requests a list of transfers received by the authenticated principle.</p></td>
+              </tr>
+            
+              <tr>
+                <td>RetryTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.RetryTransferRequest">.cs3.tx.v1beta1.RetryTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.RetryTransferResponse">.cs3.tx.v1beta1.RetryTransferResponse</a></td>
+                <td><p>Requests retrying a transfer.</p></td>
               </tr>
             
           </tbody>
@@ -3925,16 +3951,8 @@ The transfer identifier. </p></td>
                 </tr>
               
                 <tr>
-                  <td>ref</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-Reference of the resource to be transfered. </p></td>
-                </tr>
-              
-                <tr>
                   <td>status</td>
-                  <td><a href="#cs3.tx.v1beta1.TxInfo.Status">TxInfo.Status</a></td>
+                  <td><a href="#cs3.tx.v1beta1.Status">Status</a></td>
                   <td></td>
                   <td><p>REQUIRED.
 The transfer status. Eg.: STATUS_TRANSFER_FAILED.
@@ -3984,7 +4002,7 @@ Meant to be human-readable. </p></td>
       
 
       
-        <h3 id="cs3.tx.v1beta1.TxInfo.Status">TxInfo.Status</h3>
+        <h3 id="cs3.tx.v1beta1.Status">Status</h3>
         <p>Status represents transfer status.</p>
         <table class="enum-table">
           <thead>
@@ -4147,88 +4165,6 @@ Opaque information. </p></td>
 
         
       
-        <h3 id="cs3.tx.v1beta1.CreateTransferRequest">CreateTransferRequest</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>ref</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-Reference of the resource to be transfered. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>grantee</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.Grantee">cs3.storage.provider.v1beta1.Grantee</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The destination (receiver of the transfer) </p></td>
-                </tr>
-              
-                <tr>
-                  <td>opaque</td>
-                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Opaque information. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
-        <h3 id="cs3.tx.v1beta1.CreateTransferResponse">CreateTransferResponse</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>status</td>
-                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The response status. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>tx_info</td>
-                  <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-TxInfo, includes transfer id, status, description. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>opaque</td>
-                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Opaque information. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
         <h3 id="cs3.tx.v1beta1.GetTransferStatusRequest">GetTransferStatusRequest</h3>
         <p></p>
 
@@ -4303,6 +4239,104 @@ Opaque information. </p></td>
 
         
       
+        <h3 id="cs3.tx.v1beta1.ListTransfersRequest">ListTransfersRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>filters</td>
+                  <td><a href="#cs3.tx.v1beta1.ListTransfersRequest.Filter">ListTransfersRequest.Filter</a></td>
+                  <td>repeated</td>
+                  <td><p>OPTIONAL.
+The list of filters to apply if any. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.ListTransfersRequest.Filter">ListTransfersRequest.Filter</h3>
+        <p>REQUIRED.</p><p>represents a filter to apply to the request.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.tx.v1beta1.Status">Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.ListTransfersResponse">ListTransfersResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>transfers</td>
+                  <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
+                  <td>repeated</td>
+                  <td><p>REQUIRED.
+List of TxInfo types representing transfers. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.tx.v1beta1.PullTransferRequest">PullTransferRequest</h3>
         <p></p>
 
@@ -4320,14 +4354,6 @@ Opaque information. </p></td>
                   <td><p>REQUIRED.
 The target URI. Should include at the minimum all the info needed to access the source.
 https://golang.org/pkg/net/url/#URL provides a quick view of the format. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>tx_id</td>
-                  <td><a href="#cs3.tx.v1beta1.TxId">TxId</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-The transfer identifier. </p></td>
                 </tr>
               
                 <tr>
@@ -4386,6 +4412,80 @@ Opaque information. </p></td>
 
         
       
+        <h3 id="cs3.tx.v1beta1.RetryTransferRequest">RetryTransferRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>tx_id</td>
+                  <td><a href="#cs3.tx.v1beta1.TxId">TxId</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The transfer identifier. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.tx.v1beta1.RetryTransferResponse">RetryTransferResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tx_info</td>
+                  <td><a href="#cs3.tx.v1beta1.TxInfo">TxInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+TxInfo, includes ao. transfer id, status, description. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
 
       
 
@@ -4399,14 +4499,6 @@ Opaque information. </p></td>
             <tr><td>Method Name</td><td>Request Type</td><td>Response Type</td><td>Description</td></tr>
           </thead>
           <tbody>
-            
-              <tr>
-                <td>CreateTransfer</td>
-                <td><a href="#cs3.tx.v1beta1.CreateTransferRequest">CreateTransferRequest</a></td>
-                <td><a href="#cs3.tx.v1beta1.CreateTransferResponse">CreateTransferResponse</a></td>
-                <td><p>Creates (requests the destination to accept) a transfer.
-Returns a response containing a TxInfo (transfer info) object.</p></td>
-              </tr>
             
               <tr>
                 <td>PullTransfer</td>
@@ -4428,6 +4520,21 @@ Returns a PullTransferResponse</p></td>
                 <td><a href="#cs3.tx.v1beta1.CancelTransferRequest">CancelTransferRequest</a></td>
                 <td><a href="#cs3.tx.v1beta1.CancelTransferResponse">CancelTransferResponse</a></td>
                 <td><p>Requests to cancel a transfer.</p></td>
+              </tr>
+            
+              <tr>
+                <td>ListTransfers</td>
+                <td><a href="#cs3.tx.v1beta1.ListTransfersRequest">ListTransfersRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.ListTransfersResponse">ListTransfersResponse</a></td>
+                <td><p>Requests a list of transfers received by the authenticated principle.
+If a filter is specified, only transfers satisfying the filter MUST be returned.</p></td>
+              </tr>
+            
+              <tr>
+                <td>RetryTransfer</td>
+                <td><a href="#cs3.tx.v1beta1.RetryTransferRequest">RetryTransferRequest</a></td>
+                <td><a href="#cs3.tx.v1beta1.RetryTransferResponse">RetryTransferResponse</a></td>
+                <td><p>Requests retrying a transfer.</p></td>
               </tr>
             
           </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -401,6 +401,10 @@
                 </li>
               
               
+                <li>
+                  <a href="#cs3.tx.v1beta1.ListTransfersRequest.Filter.Type"><span class="badge">E</span>ListTransfersRequest.Filter.Type</a>
+                </li>
+              
               
               
                 <li>
@@ -4273,7 +4277,7 @@ The list of filters to apply if any. </p></td>
         
       
         <h3 id="cs3.tx.v1beta1.ListTransfersRequest.Filter">ListTransfersRequest.Filter</h3>
-        <p>REQUIRED.</p><p>represents a filter to apply to the request.</p>
+        <p>REQUIRED.</p><p>Represents a filter to apply to the request.</p>
 
         
           <table class="field-table">
@@ -4283,10 +4287,31 @@ The list of filters to apply if any. </p></td>
             <tbody>
               
                 <tr>
+                  <td>type</td>
+                  <td><a href="#cs3.tx.v1beta1.ListTransfersRequest.Filter.Type">ListTransfersRequest.Filter.Type</a></td>
+                  <td></td>
+                  <td><p>REQUIRED. </p></td>
+                </tr>
+              
+                <tr>
                   <td>status</td>
                   <td><a href="#cs3.tx.v1beta1.Status">Status</a></td>
                   <td></td>
-                  <td><p>REQUIRED. </p></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>share_ref</td>
+                  <td><a href="#cs3.sharing.collaboration.v1beta1.ShareReference">cs3.sharing.collaboration.v1beta1.ShareReference</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tx_id</td>
+                  <td><a href="#cs3.tx.v1beta1.TxId">TxId</a></td>
+                  <td></td>
+                  <td><p> </p></td>
                 </tr>
               
             </tbody>
@@ -4487,6 +4512,41 @@ Opaque information. </p></td>
         
       
 
+      
+        <h3 id="cs3.tx.v1beta1.ListTransfersRequest.Filter.Type">ListTransfersRequest.Filter.Type</h3>
+        <p>The filter type.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>TYPE_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_STATUS</td>
+                <td>1</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_SHARE_REF</td>
+                <td>2</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_TX_ID</td>
+                <td>3</td>
+                <td><p></p></td>
+              </tr>
+            
+          </tbody>
+        </table>
       
 
       

--- a/proto.lock
+++ b/proto.lock
@@ -2261,9 +2261,9 @@
                 "out_type": "cs3.ocm.core.v1beta1.CreateOCMCoreShareResponse"
               },
               {
-                "name": "CreateTransfer",
-                "in_type": "cs3.tx.v1beta1.CreateTransferRequest",
-                "out_type": "cs3.tx.v1beta1.CreateTransferResponse"
+                "name": "PullTransfer",
+                "in_type": "cs3.tx.v1beta1.PullTransferRequest",
+                "out_type": "cs3.tx.v1beta1.PullTransferResponse"
               },
               {
                 "name": "GetTransferStatus",
@@ -2274,6 +2274,16 @@
                 "name": "CancelTransfer",
                 "in_type": "cs3.tx.v1beta1.CancelTransferRequest",
                 "out_type": "cs3.tx.v1beta1.CancelTransferResponse"
+              },
+              {
+                "name": "ListTransfers",
+                "in_type": "cs3.tx.v1beta1.ListTransfersRequest",
+                "out_type": "cs3.tx.v1beta1.ListTransfersResponse"
+              },
+              {
+                "name": "RetryTransfer",
+                "in_type": "cs3.tx.v1beta1.RetryTransferRequest",
+                "out_type": "cs3.tx.v1beta1.RetryTransferResponse"
               }
             ]
           }
@@ -8683,7 +8693,7 @@
       "def": {
         "enums": [
           {
-            "name": "TxInfo.Status",
+            "name": "Status",
             "enum_fields": [
               {
                 "name": "STATUS_INVALID"
@@ -8752,31 +8762,26 @@
               },
               {
                 "id": 2,
-                "name": "ref",
-                "type": "cs3.storage.provider.v1beta1.Reference"
-              },
-              {
-                "id": 3,
                 "name": "status",
                 "type": "Status"
               },
               {
-                "id": 4,
+                "id": 3,
                 "name": "grantee",
                 "type": "cs3.storage.provider.v1beta1.Grantee"
               },
               {
-                "id": 5,
+                "id": 4,
                 "name": "creator",
                 "type": "cs3.identity.user.v1beta1.UserId"
               },
               {
-                "id": 6,
+                "id": 5,
                 "name": "ctime",
                 "type": "cs3.types.v1beta1.Timestamp"
               },
               {
-                "id": 7,
+                "id": 6,
                 "name": "description",
                 "type": "string"
               }
@@ -8834,27 +8839,22 @@
       "def": {
         "messages": [
           {
-            "name": "CreateTransferRequest",
+            "name": "PullTransferRequest",
             "fields": [
               {
                 "id": 1,
-                "name": "ref",
-                "type": "cs3.storage.provider.v1beta1.Reference"
+                "name": "target_uri",
+                "type": "string"
               },
               {
                 "id": 2,
-                "name": "grantee",
-                "type": "cs3.storage.provider.v1beta1.Grantee"
-              },
-              {
-                "id": 3,
                 "name": "opaque",
                 "type": "cs3.types.v1beta1.Opaque"
               }
             ]
           },
           {
-            "name": "CreateTransferResponse",
+            "name": "PullTransferResponse",
             "fields": [
               {
                 "id": 1,
@@ -8942,6 +8942,90 @@
                 "type": "cs3.types.v1beta1.Opaque"
               }
             ]
+          },
+          {
+            "name": "ListTransfersRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "filters",
+                "type": "Filter",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "Filter",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "status",
+                    "type": "Status"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ListTransfersResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "transfers",
+                "type": "TxInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "RetryTransferRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tx_id",
+                "type": "TxId"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "RetryTransferResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "tx_info",
+                "type": "TxInfo"
+              },
+              {
+                "id": 3,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
           }
         ],
         "services": [
@@ -8949,9 +9033,9 @@
             "name": "TxAPI",
             "rpcs": [
               {
-                "name": "CreateTransfer",
-                "in_type": "CreateTransferRequest",
-                "out_type": "CreateTransferResponse"
+                "name": "PullTransfer",
+                "in_type": "PullTransferRequest",
+                "out_type": "PullTransferResponse"
               },
               {
                 "name": "GetTransferStatus",
@@ -8962,6 +9046,16 @@
                 "name": "CancelTransfer",
                 "in_type": "CancelTransferRequest",
                 "out_type": "CancelTransferResponse"
+              },
+              {
+                "name": "ListTransfers",
+                "in_type": "ListTransfersRequest",
+                "out_type": "ListTransfersResponse"
+              },
+              {
+                "name": "RetryTransfer",
+                "in_type": "RetryTransferRequest",
+                "out_type": "RetryTransferResponse"
               }
             ]
           }
@@ -8969,9 +9063,6 @@
         "imports": [
           {
             "path": "cs3/rpc/v1beta1/status.proto"
-          },
-          {
-            "path": "cs3/storage/provider/v1beta1/resources.proto"
           },
           {
             "path": "cs3/tx/v1beta1/resources.proto"


### PR DESCRIPTION
When a transfer type OCM share is accepted by the user at destination the transfer becomes a pull action. At that point all the info to start the actual transfer is available (at destination) and the resource is pulled from the source to destination.
`rpc PullTransfer(PullTransferRequest) returns (PullTransferResponse)`

See https://github.com/cs3org/reva/pull/1759#issuecomment-858516581

`PullTransferRequest` fields:
`targetURI` - holds all info regarding the resource at source and the access token
(see https://github.com/cs3org/reva/pull/1759#issuecomment-863094712)

![datatx-ocmshare-pull-transfer-model](https://user-images.githubusercontent.com/13822741/123297780-2e70ae00-d518-11eb-846d-f7871bc66c59.png)

