### PR TITLE
update the storageprovider recycle api

### DIFF
--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -435,6 +435,9 @@ message ListRecycleRequest {
   // The end time range to query for recycle items.
   // The value is Unix Epoch timestamp in seconds.
   cs3.types.v1beta1.Timestamp to_ts = 3;
+  // OPTIONAL.
+  // The reference to which the action should be performed.
+  Reference ref = 4;
 }
 
 message ListRecycleResponse {
@@ -463,6 +466,9 @@ message ListRecycleStreamRequest {
   // The end time range to query for recycle items.
   // The value is Unix Epoch timestamp in seconds.
   cs3.types.v1beta1.Timestamp to_ts = 3;
+  // OPTIONAL.
+  // The reference to which the action should be performed.
+  Reference ref = 4;
 }
 
 message ListRecycleStreamResponse {

--- a/docs/index.html
+++ b/docs/index.html
@@ -13805,6 +13805,14 @@ The end time range to query for recycle items.
 The value is Unix Epoch timestamp in seconds. </p></td>
                 </tr>
               
+                <tr>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">Reference</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+The reference to which the action should be performed. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -13889,6 +13897,14 @@ The value is the Unix Epoch timestamp in seconds. </p></td>
 SHOULD be specified.
 The end time range to query for recycle items.
 The value is Unix Epoch timestamp in seconds. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">Reference</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+The reference to which the action should be performed. </p></td>
                 </tr>
               
             </tbody>

--- a/proto.lock
+++ b/proto.lock
@@ -6929,6 +6929,11 @@
                 "id": 3,
                 "name": "to_ts",
                 "type": "cs3.types.v1beta1.Timestamp"
+              },
+              {
+                "id": 4,
+                "name": "ref",
+                "type": "Reference"
               }
             ]
           },
@@ -6970,6 +6975,11 @@
                 "id": 3,
                 "name": "to_ts",
                 "type": "cs3.types.v1beta1.Timestamp"
+              },
+              {
+                "id": 4,
+                "name": "ref",
+                "type": "Reference"
               }
             ]
           },


### PR DESCRIPTION
Added a reference for the target resource on which the action should be executed. This is necessary because we want to be able to perform actions for specific resources in the recycle file tree and not only on the root of a deleted tree.

I started in https://github.com/cs3org/reva/pull/1827 to extend the recycle/trash-bin APIs in a way that actions can be performed for specific resources in the trash-bin file tree.

It works so far but the API needs some changes.
- `ListRecycle` and `ListRecycleStream` had neither a key nor a reference
- `RestoreRecycleItem` had a key and a ref 

This PR makes the Recycle API related methods consistent by adding a ref where missing and removing the key since it can be included in the reference and so we don't need to separate fields.