### PR TITLE
Extensions for the AppProviders to improve the UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ pull:
 
 build: pull
 	docker run -v ${pwd}:/root/cs3apis cs3org/cs3apis cs3apis-build -build-proto
+	# restore ownership of the `docs` folder as docker runs as root
+	chown -R `ls -ld . | awk '{print $$3 ":" $$4}'` docs
 python: pull
 	docker run -v ${pwd}:/root/cs3apis cs3org/cs3apis cs3apis-build -build-python
 go: pull

--- a/cs3/app/provider/v1beta1/provider_api.proto
+++ b/cs3/app/provider/v1beta1/provider_api.proto
@@ -53,7 +53,7 @@ import "cs3/types/v1beta1/types.proto";
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
 service ProviderAPI {
-  // Returns the App provider URL
+  // Returns the App URL and all necessary info to open a resource in an online editor.
   // MUST return CODE_NOT_FOUND if the resource does not exist.
   rpc OpenInApp(OpenInAppRequest) returns (OpenInAppResponse);
 }

--- a/cs3/app/registry/v1beta1/registry_api.proto
+++ b/cs3/app/registry/v1beta1/registry_api.proto
@@ -57,7 +57,7 @@ service RegistryAPI {
   rpc AddAppProvider(AddAppProviderRequest) returns (AddAppProviderResponse);
   // Returns a list of the available app providers known by this registry.
   rpc ListAppProviders(ListAppProvidersRequest) returns (ListAppProvidersResponse);
-  // Returns a list of the supported mime types along with the apps which they can opened with.
+  // Returns a list of the supported mime types along with the apps which they can be opened with.
   rpc ListSupportedMimeTypes(ListSupportedMimeTypesRequest) returns (ListSupportedMimeTypesResponse);
   // Returns the default app provider which serves a specified mime type.
   rpc GetDefaultAppProviderForMimeType(GetDefaultAppProviderForMimeTypeRequest) returns (GetDefaultAppProviderForMimeTypeResponse);
@@ -136,8 +136,8 @@ message ListSupportedMimeTypesResponse {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
-  // The list of supported mime types with the apps which they can be opened with.
-  map<string, AppProviderList> mime_types = 3;
+  // The list of supported mime types and their properties.
+  repeated MimeTypeInfo mime_types = 3;
 }
 
 message GetDefaultAppProviderForMimeTypeRequest {

--- a/cs3/app/registry/v1beta1/resources.proto
+++ b/cs3/app/registry/v1beta1/resources.proto
@@ -42,20 +42,30 @@ message ProviderInfo {
   // The address where the app provider can be reached.
   // For example, tcp://localhost:1099.
   string address = 3;
+  // REQUIRED.
+  // The capability of the underlying app.
+  enum Capability {
+    CAPABILITY_INVALID = 0;
+    // The app is a simple viewer.
+    CAPABILITY_VIEWER = 1;
+    // The app is a full editor.
+    CAPABILITY_EDITOR = 2;
+  }
+  Capability capability = 4;
   // OPTIONAL.
-  // A human-readable name of the app provider.
-  string name = 4;
+  // A human-readable name of the underlying app.
+  string name = 5;
   // OPTIONAL.
   // Information to describe the functionalities
   // offered by the app provider. Meant to be read
   // by humans.
-  string description = 5;
+  string description = 6;
   // OPTIONAL.
   // A URI to a static asset which represents the app icon.
-  string icon = 6;
+  string icon = 7;
   // OPTIONAL.
   // Whether the app can be opened only on desktop
-  bool desktop_only = 7;
+  bool desktop_only = 8;
 }
 
 // Holds a list of app providers which can open a particular mime type.

--- a/cs3/app/registry/v1beta1/resources.proto
+++ b/cs3/app/registry/v1beta1/resources.proto
@@ -57,7 +57,7 @@ message ProviderInfo {
   string name = 5;
   // OPTIONAL.
   // Information to describe the functionalities
-  // offered by the app provider. Meant to be read
+  // offered by the underlying app. Meant to be read
   // by humans.
   string description = 6;
   // OPTIONAL.
@@ -68,7 +68,27 @@ message ProviderInfo {
   bool desktop_only = 8;
 }
 
-// Holds a list of app providers which can open a particular mime type.
-message AppProviderList {
-  repeated ProviderInfo app_providers = 1;
+// Represents a mime type and its corresponding file extension.
+message MimeTypeInfo {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The mime type.
+  string mime_type = 2;
+  // REQUIRED.
+  // The file extension mapped to this mime type.
+  string ext = 3;
+  // REQUIRED.
+  // The list of app providers which can open this mime type
+  repeated ProviderInfo app_providers = 4;
+  // OPTIONAL.
+  // The friendly name of this mime type.
+  string name = 5;
+  // OPTIONAL.
+  // Human-readable information to describe the mime type.
+  string description = 6;
+  // OPTIONAL.
+  // A URI to a static asset which represents the mime type icon.
+  string icon = 7;
 }

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -179,7 +179,11 @@ service GatewayAPI {
   // ************************ APP PROVIDER ********************/
   // *****************************************************************/
 
-  // Returns the App provider URL, which allows the user to open a resource in an online editor.
+  // Creates a new file to be opened by an app. The new file MAY be either
+  // empty or generated out of a template if the AppProvider has such capability.
+  rpc CreateFileForApp(CreateFileForAppRequest) returns (CreateFileForAppResponse);
+  // Returns the App URL and all necessary info to open a resource in an online editor.
+  // MUST return CODE_NOT_FOUND if the resource does not exist.
   rpc OpenInApp(OpenInAppRequest) returns (cs3.app.provider.v1beta1.OpenInAppResponse);
   // *****************************************************************/
   // ************************ USER SHARE PROVIDER ********************/
@@ -527,6 +531,33 @@ message ListAuthProvidersResponse {
   // The list of auth types.
   // TODO(labkode): maybe add description?
   repeated string types = 3;
+}
+
+message CreateFileForAppRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The target container where the file has to be created.
+  cs3.storage.provider.v1beta1.Reference ref = 2;
+  // REQUIRED.
+  // The name of the file to be created.
+  string filename = 3;
+  // OPTIONAL.
+  // A reference to a template that SHOULD be used to create the file.
+  string template = 4;
+}
+
+message CreateFileForAppResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The resourceInfo of the file that was created.
+  cs3.storage.provider.v1beta1.ResourceInfo resource_info = 3;
 }
 
 message OpenInAppRequest {

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -179,9 +179,6 @@ service GatewayAPI {
   // ************************ APP PROVIDER ********************/
   // *****************************************************************/
 
-  // Creates a new file to be opened by an app. The new file MAY be either
-  // empty or generated out of a template if the AppProvider has such capability.
-  rpc CreateFileForApp(CreateFileForAppRequest) returns (CreateFileForAppResponse);
   // Returns the App URL and all necessary info to open a resource in an online editor.
   // MUST return CODE_NOT_FOUND if the resource does not exist.
   rpc OpenInApp(OpenInAppRequest) returns (cs3.app.provider.v1beta1.OpenInAppResponse);
@@ -531,33 +528,6 @@ message ListAuthProvidersResponse {
   // The list of auth types.
   // TODO(labkode): maybe add description?
   repeated string types = 3;
-}
-
-message CreateFileForAppRequest {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  // The target container where the file has to be created.
-  cs3.storage.provider.v1beta1.Reference ref = 2;
-  // REQUIRED.
-  // The name of the file to be created.
-  string filename = 3;
-  // OPTIONAL.
-  // A reference to a template that SHOULD be used to create the file.
-  string template = 4;
-}
-
-message CreateFileForAppResponse {
-  // REQUIRED.
-  // The response status.
-  cs3.rpc.v1beta1.Status status = 1;
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 2;
-  // REQUIRED.
-  // The resourceInfo of the file that was created.
-  cs3.storage.provider.v1beta1.ResourceInfo resource_info = 3;
 }
 
 message OpenInAppRequest {

--- a/docs/index.html
+++ b/docs/index.html
@@ -583,10 +583,6 @@
                 </li>
               
                 <li>
-                  <a href="#cs3.app.registry.v1beta1.ListSupportedMimeTypesResponse.MimeTypesEntry"><span class="badge">M</span>ListSupportedMimeTypesResponse.MimeTypesEntry</a>
-                </li>
-              
-                <li>
                   <a href="#cs3.app.registry.v1beta1.SetDefaultAppProviderForMimeTypeRequest"><span class="badge">M</span>SetDefaultAppProviderForMimeTypeRequest</a>
                 </li>
               
@@ -610,13 +606,17 @@
             <ul>
               
                 <li>
-                  <a href="#cs3.app.registry.v1beta1.AppProviderList"><span class="badge">M</span>AppProviderList</a>
+                  <a href="#cs3.app.registry.v1beta1.MimeTypeInfo"><span class="badge">M</span>MimeTypeInfo</a>
                 </li>
               
                 <li>
                   <a href="#cs3.app.registry.v1beta1.ProviderInfo"><span class="badge">M</span>ProviderInfo</a>
                 </li>
               
+              
+                <li>
+                  <a href="#cs3.app.registry.v1beta1.ProviderInfo.Capability"><span class="badge">E</span>ProviderInfo.Capability</a>
+                </li>
               
               
               
@@ -5622,41 +5622,10 @@ Opaque information. </p></td>
               
                 <tr>
                   <td>mime_types</td>
-                  <td><a href="#cs3.app.registry.v1beta1.ListSupportedMimeTypesResponse.MimeTypesEntry">ListSupportedMimeTypesResponse.MimeTypesEntry</a></td>
+                  <td><a href="#cs3.app.registry.v1beta1.MimeTypeInfo">MimeTypeInfo</a></td>
                   <td>repeated</td>
                   <td><p>REQUIRED.
-The list of supported mime types with the apps which they can be opened with. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
-        <h3 id="cs3.app.registry.v1beta1.ListSupportedMimeTypesResponse.MimeTypesEntry">ListSupportedMimeTypesResponse.MimeTypesEntry</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>key</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p> </p></td>
-                </tr>
-              
-                <tr>
-                  <td>value</td>
-                  <td><a href="#cs3.app.registry.v1beta1.AppProviderList">AppProviderList</a></td>
-                  <td></td>
-                  <td><p> </p></td>
+The list of supported mime types and their properties. </p></td>
                 </tr>
               
             </tbody>
@@ -5780,7 +5749,7 @@ MUST return CODE_NOT_FOUND if no providers are available.</p></td>
                 <td>ListSupportedMimeTypes</td>
                 <td><a href="#cs3.app.registry.v1beta1.ListSupportedMimeTypesRequest">ListSupportedMimeTypesRequest</a></td>
                 <td><a href="#cs3.app.registry.v1beta1.ListSupportedMimeTypesResponse">ListSupportedMimeTypesResponse</a></td>
-                <td><p>Returns a list of the supported mime types along with the apps which they can opened with.</p></td>
+                <td><p>Returns a list of the supported mime types along with the apps which they can be opened with.</p></td>
               </tr>
             
               <tr>
@@ -5809,8 +5778,8 @@ MUST return CODE_NOT_FOUND if no providers are available.</p></td>
       <p></p>
 
       
-        <h3 id="cs3.app.registry.v1beta1.AppProviderList">AppProviderList</h3>
-        <p>Holds a list of app providers which can open a particular mime type.</p>
+        <h3 id="cs3.app.registry.v1beta1.MimeTypeInfo">MimeTypeInfo</h3>
+        <p>Represents a mime type and its corresponding file extension.</p>
 
         
           <table class="field-table">
@@ -5820,10 +5789,59 @@ MUST return CODE_NOT_FOUND if no providers are available.</p></td>
             <tbody>
               
                 <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>mime_type</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The mime type. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ext</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The file extension mapped to this mime type. </p></td>
+                </tr>
+              
+                <tr>
                   <td>app_providers</td>
                   <td><a href="#cs3.app.registry.v1beta1.ProviderInfo">ProviderInfo</a></td>
                   <td>repeated</td>
-                  <td><p> </p></td>
+                  <td><p>REQUIRED.
+The list of app providers which can open this mime type </p></td>
+                </tr>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+The friendly name of this mime type. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>description</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Human-readable information to describe the mime type. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>icon</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A URI to a static asset which represents the mime type icon. </p></td>
                 </tr>
               
             </tbody>
@@ -5869,11 +5887,18 @@ For example, tcp://localhost:1099. </p></td>
                 </tr>
               
                 <tr>
+                  <td>capability</td>
+                  <td><a href="#cs3.app.registry.v1beta1.ProviderInfo.Capability">ProviderInfo.Capability</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
                   <td>name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-A human-readable name of the app provider. </p></td>
+A human-readable name of the underlying app. </p></td>
                 </tr>
               
                 <tr>
@@ -5882,7 +5907,7 @@ A human-readable name of the app provider. </p></td>
                   <td></td>
                   <td><p>OPTIONAL.
 Information to describe the functionalities
-offered by the app provider. Meant to be read
+offered by the underlying app. Meant to be read
 by humans. </p></td>
                 </tr>
               
@@ -5910,6 +5935,35 @@ Whether the app can be opened only on desktop </p></td>
         
       
 
+      
+        <h3 id="cs3.app.registry.v1beta1.ProviderInfo.Capability">ProviderInfo.Capability</h3>
+        <p>REQUIRED.</p><p>The capability of the underlying app.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>CAPABILITY_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>CAPABILITY_VIEWER</td>
+                <td>1</td>
+                <td><p>The app is a simple viewer.</p></td>
+              </tr>
+            
+              <tr>
+                <td>CAPABILITY_EDITOR</td>
+                <td>2</td>
+                <td><p>The app is a full editor.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
       
 
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -187,14 +187,6 @@
                 </li>
               
                 <li>
-                  <a href="#cs3.gateway.v1beta1.CreateFileForAppRequest"><span class="badge">M</span>CreateFileForAppRequest</a>
-                </li>
-              
-                <li>
-                  <a href="#cs3.gateway.v1beta1.CreateFileForAppResponse"><span class="badge">M</span>CreateFileForAppResponse</a>
-                </li>
-              
-                <li>
                   <a href="#cs3.gateway.v1beta1.GetQuotaRequest"><span class="badge">M</span>GetQuotaRequest</a>
                 </li>
               
@@ -2054,96 +2046,6 @@ The authenticated user. </p></td>
 
         
       
-        <h3 id="cs3.gateway.v1beta1.CreateFileForAppRequest">CreateFileForAppRequest</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>opaque</td>
-                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Opaque information. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>ref</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The target container where the file has to be created. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>filename</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The name of the file to be created. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>template</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-A reference to a template that SHOULD be used to create the file. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
-        <h3 id="cs3.gateway.v1beta1.CreateFileForAppResponse">CreateFileForAppResponse</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>status</td>
-                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The response status. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>opaque</td>
-                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Opaque information. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>resource_info</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.ResourceInfo">cs3.storage.provider.v1beta1.ResourceInfo</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The resourceInfo of the file that was created. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
         <h3 id="cs3.gateway.v1beta1.GetQuotaRequest">GetQuotaRequest</h3>
         <p></p>
 
@@ -2871,14 +2773,6 @@ Arbitrary metadata is returned in a cs3.storage.provider.v1beta1.ResourceInfo.</
 *****************************************************************/
 ************************ APP PROVIDER ********************/
 *****************************************************************/</p></td>
-              </tr>
-            
-              <tr>
-                <td>CreateFileForApp</td>
-                <td><a href="#cs3.gateway.v1beta1.CreateFileForAppRequest">CreateFileForAppRequest</a></td>
-                <td><a href="#cs3.gateway.v1beta1.CreateFileForAppResponse">CreateFileForAppResponse</a></td>
-                <td><p>Creates a new file to be opened by an app. The new file MAY be either
-empty or generated out of a template if the AppProvider has such capability.</p></td>
               </tr>
             
               <tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -187,6 +187,14 @@
                 </li>
               
                 <li>
+                  <a href="#cs3.gateway.v1beta1.CreateFileForAppRequest"><span class="badge">M</span>CreateFileForAppRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.gateway.v1beta1.CreateFileForAppResponse"><span class="badge">M</span>CreateFileForAppResponse</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.gateway.v1beta1.GetQuotaRequest"><span class="badge">M</span>GetQuotaRequest</a>
                 </li>
               
@@ -2046,6 +2054,96 @@ The authenticated user. </p></td>
 
         
       
+        <h3 id="cs3.gateway.v1beta1.CreateFileForAppRequest">CreateFileForAppRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">cs3.storage.provider.v1beta1.Reference</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The target container where the file has to be created. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>filename</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The name of the file to be created. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>template</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A reference to a template that SHOULD be used to create the file. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.gateway.v1beta1.CreateFileForAppResponse">CreateFileForAppResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>resource_info</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.ResourceInfo">cs3.storage.provider.v1beta1.ResourceInfo</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The resourceInfo of the file that was created. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.gateway.v1beta1.GetQuotaRequest">GetQuotaRequest</h3>
         <p></p>
 
@@ -2776,10 +2874,19 @@ Arbitrary metadata is returned in a cs3.storage.provider.v1beta1.ResourceInfo.</
               </tr>
             
               <tr>
+                <td>CreateFileForApp</td>
+                <td><a href="#cs3.gateway.v1beta1.CreateFileForAppRequest">CreateFileForAppRequest</a></td>
+                <td><a href="#cs3.gateway.v1beta1.CreateFileForAppResponse">CreateFileForAppResponse</a></td>
+                <td><p>Creates a new file to be opened by an app. The new file MAY be either
+empty or generated out of a template if the AppProvider has such capability.</p></td>
+              </tr>
+            
+              <tr>
                 <td>OpenInApp</td>
                 <td><a href="#cs3.gateway.v1beta1.OpenInAppRequest">OpenInAppRequest</a></td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenInAppResponse">.cs3.app.provider.v1beta1.OpenInAppResponse</a></td>
-                <td><p>Returns the App provider URL, which allows the user to open a resource in an online editor.
+                <td><p>Returns the App URL and all necessary info to open a resource in an online editor.
+MUST return CODE_NOT_FOUND if the resource does not exist.
 
 *****************************************************************/
 ************************ USER SHARE PROVIDER ********************/
@@ -5145,7 +5252,7 @@ Usually the rendering happens by using HTML iframes or in separate browser tabs.
                 <td>OpenInApp</td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenInAppRequest">OpenInAppRequest</a></td>
                 <td><a href="#cs3.app.provider.v1beta1.OpenInAppResponse">OpenInAppResponse</a></td>
-                <td><p>Returns the App provider URL
+                <td><p>Returns the App URL and all necessary info to open a resource in an online editor.
 MUST return CODE_NOT_FOUND if the resource does not exist.</p></td>
               </tr>
             

--- a/proto.lock
+++ b/proto.lock
@@ -678,16 +678,12 @@
                 "id": 2,
                 "name": "opaque",
                 "type": "cs3.types.v1beta1.Opaque"
-              }
-            ],
-            "maps": [
+              },
               {
-                "key_type": "string",
-                "field": {
-                  "id": 3,
-                  "name": "mime_types",
-                  "type": "AppProviderList"
-                }
+                "id": 3,
+                "name": "mime_types",
+                "type": "MimeTypeInfo",
+                "is_repeated": true
               }
             ]
           },
@@ -851,6 +847,24 @@
     {
       "protopath": "cs3:/:app:/:registry:/:v1beta1:/:resources.proto",
       "def": {
+        "enums": [
+          {
+            "name": "ProviderInfo.Capability",
+            "enum_fields": [
+              {
+                "name": "CAPABILITY_INVALID"
+              },
+              {
+                "name": "CAPABILITY_VIEWER",
+                "integer": 1
+              },
+              {
+                "name": "CAPABILITY_EDITOR",
+                "integer": 2
+              }
+            ]
+          }
+        ],
         "messages": [
           {
             "name": "ProviderInfo",
@@ -873,34 +887,69 @@
               },
               {
                 "id": 4,
+                "name": "capability",
+                "type": "Capability"
+              },
+              {
+                "id": 5,
                 "name": "name",
                 "type": "string"
               },
               {
-                "id": 5,
+                "id": 6,
                 "name": "description",
                 "type": "string"
               },
               {
-                "id": 6,
+                "id": 7,
                 "name": "icon",
                 "type": "string"
               },
               {
-                "id": 7,
+                "id": 8,
                 "name": "desktop_only",
                 "type": "bool"
               }
             ]
           },
           {
-            "name": "AppProviderList",
+            "name": "MimeTypeInfo",
             "fields": [
               {
                 "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "mime_type",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "ext",
+                "type": "string"
+              },
+              {
+                "id": 4,
                 "name": "app_providers",
                 "type": "ProviderInfo",
                 "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "description",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "icon",
+                "type": "string"
               }
             ]
           }
@@ -5009,6 +5058,10 @@
               {
                 "name": "TYPE_GRANTEE_TYPE",
                 "integer": 5
+              },
+              {
+                "name": "TYPE_EXCLUDE_DENIALS",
+                "integer": 6
               }
             ]
           }


### PR DESCRIPTION
This PR introduces further extensions for the open-in-app workflow:
* `AppProvider`s expose a `capability` to identify fully fledged editors vs viewers
* Mime types are defined including a friendly name and a corresponding file extension

This allows the UI to e.g. populate a **New** menu with all types for which an `editor` AppProvider is defined.

The extensions constitute breaking changes for the protobuf bindings, and can be merged once cs3org/reva#2067 is ready to be merged.