### PR TITLE
add TouchFile

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -99,7 +99,7 @@ service GatewayAPI {
   // Creates a new resource of type file.
   // MUST return CODE_PRECONDITION_FAILED if the file
   // cannot be created at the specified reference.
-  rpc CreateFile(cs3.storage.provider.v1beta1.CreateFileRequest) returns (cs3.storage.provider.v1beta1.CreateFileResponse);
+  rpc TouchFile(cs3.storage.provider.v1beta1.TouchFileRequest) returns (cs3.storage.provider.v1beta1.TouchFileResponse);
   // Deletes a resource.
   // If a resource specifies the non-empty container (directory, ...),
   // then the entire directory is deleted recursively.

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -96,6 +96,10 @@ service GatewayAPI {
   // MUST return CODE_PRECONDITION_FAILED if the container
   // cannot be created at the specified reference.
   rpc CreateContainer(cs3.storage.provider.v1beta1.CreateContainerRequest) returns (cs3.storage.provider.v1beta1.CreateContainerResponse);
+  // Creates a new resource of type file.
+  // MUST return CODE_PRECONDITION_FAILED if the file
+  // cannot be created at the specified reference.
+  rpc CreateFile(cs3.storage.provider.v1beta1.CreateFileRequest) returns (cs3.storage.provider.v1beta1.CreateFileResponse);
   // Deletes a resource.
   // If a resource specifies the non-empty container (directory, ...),
   // then the entire directory is deleted recursively.

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -57,6 +57,10 @@ service ProviderAPI {
   // MUST return CODE_PRECONDITION_FAILED if the container
   // cannot be created at the specified reference.
   rpc CreateContainer(CreateContainerRequest) returns (CreateContainerResponse);
+  // Creates a new resource of type file.
+  // MUST return CODE_PRECONDITION_FAILED if the file
+  // cannot be created at the specified reference.
+  rpc CreateFile(CreateFileRequest) returns (CreateFileResponse);
   // Deletes a resource.
   // If a resource specifies the non-empty container (directory, ...),
   // then the entire directory is deleted recursively.
@@ -229,6 +233,24 @@ message CreateContainerRequest {
 }
 
 message CreateContainerResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+}
+
+message CreateFileRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The reference to which the action should be performed.
+  Reference ref = 2;
+}
+
+message CreateFileResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -60,7 +60,7 @@ service ProviderAPI {
   // Creates a new resource of type file.
   // MUST return CODE_PRECONDITION_FAILED if the file
   // cannot be created at the specified reference.
-  rpc CreateFile(CreateFileRequest) returns (CreateFileResponse);
+  rpc TouchFile(TouchFileRequest) returns (TouchFileResponse);
   // Deletes a resource.
   // If a resource specifies the non-empty container (directory, ...),
   // then the entire directory is deleted recursively.
@@ -241,7 +241,7 @@ message CreateContainerResponse {
   cs3.types.v1beta1.Opaque opaque = 2;
 }
 
-message CreateFileRequest {
+message TouchFileRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
@@ -250,7 +250,7 @@ message CreateFileRequest {
   Reference ref = 2;
 }
 
-message CreateFileResponse {
+message TouchFileResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1511,14 +1511,6 @@
                 </li>
               
                 <li>
-                  <a href="#cs3.storage.provider.v1beta1.CreateFileRequest"><span class="badge">M</span>CreateFileRequest</a>
-                </li>
-              
-                <li>
-                  <a href="#cs3.storage.provider.v1beta1.CreateFileResponse"><span class="badge">M</span>CreateFileResponse</a>
-                </li>
-              
-                <li>
                   <a href="#cs3.storage.provider.v1beta1.CreateHomeRequest"><span class="badge">M</span>CreateHomeRequest</a>
                 </li>
               
@@ -1728,6 +1720,14 @@
               
                 <li>
                   <a href="#cs3.storage.provider.v1beta1.StatResponse"><span class="badge">M</span>StatResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.storage.provider.v1beta1.TouchFileRequest"><span class="badge">M</span>TouchFileRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.storage.provider.v1beta1.TouchFileResponse"><span class="badge">M</span>TouchFileResponse</a>
                 </li>
               
                 <li>
@@ -2427,9 +2427,9 @@ cannot be created at the specified reference.</p></td>
               </tr>
             
               <tr>
-                <td>CreateFile</td>
-                <td><a href="#cs3.storage.provider.v1beta1.CreateFileRequest">.cs3.storage.provider.v1beta1.CreateFileRequest</a></td>
-                <td><a href="#cs3.storage.provider.v1beta1.CreateFileResponse">.cs3.storage.provider.v1beta1.CreateFileResponse</a></td>
+                <td>TouchFile</td>
+                <td><a href="#cs3.storage.provider.v1beta1.TouchFileRequest">.cs3.storage.provider.v1beta1.TouchFileRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.TouchFileResponse">.cs3.storage.provider.v1beta1.TouchFileResponse</a></td>
                 <td><p>Creates a new resource of type file.
 MUST return CODE_PRECONDITION_FAILED if the file
 cannot be created at the specified reference.</p></td>
@@ -12882,72 +12882,6 @@ Opaque information. </p></td>
 
         
       
-        <h3 id="cs3.storage.provider.v1beta1.CreateFileRequest">CreateFileRequest</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>opaque</td>
-                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Opaque information. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>ref</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.Reference">Reference</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The reference to which the action should be performed. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
-        <h3 id="cs3.storage.provider.v1beta1.CreateFileResponse">CreateFileResponse</h3>
-        <p></p>
-
-        
-          <table class="field-table">
-            <thead>
-              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
-            </thead>
-            <tbody>
-              
-                <tr>
-                  <td>status</td>
-                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
-                  <td></td>
-                  <td><p>REQUIRED.
-The response status. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>opaque</td>
-                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-Opaque information. </p></td>
-                </tr>
-              
-            </tbody>
-          </table>
-
-          
-
-        
-      
         <h3 id="cs3.storage.provider.v1beta1.CreateHomeRequest">CreateHomeRequest</h3>
         <p></p>
 
@@ -15025,6 +14959,72 @@ The resource information. </p></td>
 
         
       
+        <h3 id="cs3.storage.provider.v1beta1.TouchFileRequest">TouchFileRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">Reference</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The reference to which the action should be performed. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.storage.provider.v1beta1.TouchFileResponse">TouchFileResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.storage.provider.v1beta1.UnsetArbitraryMetadataRequest">UnsetArbitraryMetadataRequest</h3>
         <p></p>
 
@@ -15319,9 +15319,9 @@ cannot be created at the specified reference.</p></td>
               </tr>
             
               <tr>
-                <td>CreateFile</td>
-                <td><a href="#cs3.storage.provider.v1beta1.CreateFileRequest">CreateFileRequest</a></td>
-                <td><a href="#cs3.storage.provider.v1beta1.CreateFileResponse">CreateFileResponse</a></td>
+                <td>TouchFile</td>
+                <td><a href="#cs3.storage.provider.v1beta1.TouchFileRequest">TouchFileRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.TouchFileResponse">TouchFileResponse</a></td>
                 <td><p>Creates a new resource of type file.
 MUST return CODE_PRECONDITION_FAILED if the file
 cannot be created at the specified reference.</p></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1511,6 +1511,14 @@
                 </li>
               
                 <li>
+                  <a href="#cs3.storage.provider.v1beta1.CreateFileRequest"><span class="badge">M</span>CreateFileRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#cs3.storage.provider.v1beta1.CreateFileResponse"><span class="badge">M</span>CreateFileResponse</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.storage.provider.v1beta1.CreateHomeRequest"><span class="badge">M</span>CreateHomeRequest</a>
                 </li>
               
@@ -2415,6 +2423,15 @@ third-party applications.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.CreateContainerResponse">.cs3.storage.provider.v1beta1.CreateContainerResponse</a></td>
                 <td><p>Creates a new resource of type container.
 MUST return CODE_PRECONDITION_FAILED if the container
+cannot be created at the specified reference.</p></td>
+              </tr>
+            
+              <tr>
+                <td>CreateFile</td>
+                <td><a href="#cs3.storage.provider.v1beta1.CreateFileRequest">.cs3.storage.provider.v1beta1.CreateFileRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.CreateFileResponse">.cs3.storage.provider.v1beta1.CreateFileResponse</a></td>
+                <td><p>Creates a new resource of type file.
+MUST return CODE_PRECONDITION_FAILED if the file
 cannot be created at the specified reference.</p></td>
               </tr>
             
@@ -12865,6 +12882,72 @@ Opaque information. </p></td>
 
         
       
+        <h3 id="cs3.storage.provider.v1beta1.CreateFileRequest">CreateFileRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ref</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Reference">Reference</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The reference to which the action should be performed. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="cs3.storage.provider.v1beta1.CreateFileResponse">CreateFileResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#cs3.rpc.v1beta1.Status">cs3.rpc.v1beta1.Status</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The response status. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="cs3.storage.provider.v1beta1.CreateHomeRequest">CreateHomeRequest</h3>
         <p></p>
 
@@ -15232,6 +15315,15 @@ MUST return CODE_NOT_FOUND if the reference does not exist</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.CreateContainerResponse">CreateContainerResponse</a></td>
                 <td><p>Creates a new resource of type container.
 MUST return CODE_PRECONDITION_FAILED if the container
+cannot be created at the specified reference.</p></td>
+              </tr>
+            
+              <tr>
+                <td>CreateFile</td>
+                <td><a href="#cs3.storage.provider.v1beta1.CreateFileRequest">CreateFileRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.CreateFileResponse">CreateFileResponse</a></td>
+                <td><p>Creates a new resource of type file.
+MUST return CODE_PRECONDITION_FAILED if the file
 cannot be created at the specified reference.</p></td>
               </tr>
             


### PR DESCRIPTION
## Description
~`CreateFile`~ `TouchFile` can be used to create an empty file. This is the file counterpart of `CreateContainer`. It allows one to easily create a file in order to reference it with a storage and opaque id. (Referencing it with a path or a relative path is already possible without the existing file).

## Alternative considerations
One could use the `InitiateFileUpload` in order to upload a zero byte file. it will give you an array of upload methods (eg. TUS and simple) and you can then invoke the upload of the zero byte file.

This means you need an http request ( in case of the simple protocol ) in addition to the InitiateFileUpload grpc request.

To spare that http request, some file system implementations, eg the decomposedfs implement a shortcut (https://github.com/cs3org/reva/blob/4879bf6be97aecc9e30ad999355342b6ca6188f1/pkg/storage/utils/decomposedfs/upload.go#L300-L308) for zero byte files. The cs3 api client has no way to check that the upload already finishend, because there are no return codes. Therefore bugs like https://github.com/owncloud/ocis/issues/2609 arise. 
In my opinion, this shortcut for zero byte files is also wrong, because the InitiateFileUpload is only an intend to upload a file. The actual file should created when the file is finally uploaded by using the offered upload protocols (eg. simple or TUS). This also applies to zero byte files.