### PR TITLE
Rework Lock API metadata and add missing argument to Unlock

### DIFF
--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -878,6 +878,9 @@ message UnlockRequest {
   // REQUIRED.
   // The reference the lock is associated to.
   Reference ref = 2;
+  // REQUIRED.
+  // The lock metadata.
+  Lock lock = 3;
 }
 
 message UnlockResponse {

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -141,7 +141,7 @@ enum LockType {
 //   "type" : "<LOCK_TYPE>",
 //   "h" : "<holder>",
 //   "md" : "<metadata>",
-//   "mtime" : "<Unix timestamp>"
+//   "exp" : "<Unix timestamp>"
 // }
 message Lock {
   // The type of lock.
@@ -153,11 +153,10 @@ message Lock {
     // An application name if the lock is held by an app.
     string app_name = 3;
   }
-  // Some arbitrary metadata associated with the lock.
+  // OPTIONAL. Some arbitrary metadata associated with the lock.
   string metadata = 4;
-  // The last modification time of the lock.
-  // The value is Unix Epoch timestamp in seconds.
-  cs3.types.v1beta1.Timestamp mtime = 5;
+  // OPTIONAL. The time when the lock will expire.
+  cs3.types.v1beta1.Timestamp expiration = 5;
 }
 
 // The available types of resources.

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -141,7 +141,8 @@ enum LockType {
 // of this metadata according to their constraints, a reference
 // implementation is given here. The lock SHOULD be stored
 // as an extended attribute on the referenced filesystem entry.
-// It MUST NOT be accessible via the Stat/SetArbitraryMetadata APIs.
+// Such extended attribute MUST NOT be exposed via the `Stat` and `SetArbitraryMetadata` APIs.
+// Instead, the `ResourceInfo.Lock` attribute MUST be populated if a lock exists for the given reference.
 message Lock {
   // OPTIONAL.
   // Opaque information.

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -90,6 +90,9 @@ message ResourceInfo {
   // OPTIONAL.
   // Arbitrary metadata attached to a resource.
   ArbitraryMetadata arbitrary_metadata = 14;
+  // OPTIONAL.
+  // Locks on this resource.
+  repeated Lock locks = 15;
 }
 
 // CanonicalMetadata contains extra metadata

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -91,8 +91,11 @@ message ResourceInfo {
   // Arbitrary metadata attached to a resource.
   ArbitraryMetadata arbitrary_metadata = 14;
   // OPTIONAL.
-  // Lock on this resource.
+  // Exclusive or write lock on this resource that will limit modification of the resource to holders of the lock. Can be used by WOPI or other apps requiring exclusive locks.
   Lock lock = 15;
+  // OPTIONAL.
+  // Advisory locks on this resource. Can be used for shared locks or other forms of collaborative locks.
+  repeated Lock advisory_locks = 16;
 }
 
 // CanonicalMetadata contains extra metadata
@@ -140,17 +143,19 @@ enum LockType {
 // as an extended attribute on the referenced filesystem entry.
 // It MUST NOT be accessible via the Stat/SetArbitraryMetadata APIs.
 message Lock {
-  // The type of lock.
-  LockType type = 1;
-  // The entities holding the lock.
-  // REQUIRED. At least one userid of the users participating in the lock.
-  repeated cs3.identity.user.v1beta1.UserId users = 2;
-  // An application name if the lock is held by an app.
-  string app_name = 3;
-  // OPTIONAL. Some arbitrary metadata associated with the lock.
-  string metadata = 4;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED. The id of the lock, eg. the X-WOPI-Lock id or the WebDAV opaquelocktoken.
+  string lock_id = 2;
+  // REQUIRED. The type of lock.
+  LockType type = 3;
+  // OPTIONAL. The userid of a user holding the lock.
+  cs3.identity.user.v1beta1.UserId user = 4;
+  // OPTIONAL An application name if the lock is held by an app.
+  string app_name = 5;
   // OPTIONAL. The time when the lock will expire.
-  cs3.types.v1beta1.Timestamp expiration = 5;
+  cs3.types.v1beta1.Timestamp expiration = 6;
 }
 
 // The available types of resources.

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -146,17 +146,22 @@ message Lock {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED. The id of the lock, eg. the X-WOPI-Lock id or the WebDAV opaquelocktoken.
+  // REQUIRED.
+  // The id of the lock, eg. the X-WOPI-Lock id or the WebDAV opaquelocktoken.
   string lock_id = 2;
-  // REQUIRED. The type of lock.
+  // REQUIRED.
+  // The type of lock.
   LockType type = 3;
   // OPTIONAL.
   // The userid of a user, which represents either the lock holder, or the user that last created/modified the lock.
   // When non empty, `RefreshLock` and `Unlock` operations MUST check their request's content against it.
   cs3.identity.user.v1beta1.UserId user = 4;
-  // OPTIONAL An application name if the lock is held by an app.
+  // OPTIONAL.
+  // An application name if the lock is held by an app.
+  // When non empty, `RefreshLock` and `Unlock` operations MUST check their request's content against it.
   string app_name = 5;
-  // OPTIONAL. The time when the lock will expire.
+  // OPTIONAL.
+  // The time when the lock will expire.
   cs3.types.v1beta1.Timestamp expiration = 6;
 }
 

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -150,7 +150,9 @@ message Lock {
   string lock_id = 2;
   // REQUIRED. The type of lock.
   LockType type = 3;
-  // OPTIONAL. The userid of a user holding the lock.
+  // OPTIONAL.
+  // The userid of a user, which represents either the lock holder, or the user that last created/modified the lock.
+  // When non empty, `RefreshLock` and `Unlock` operations MUST check their request's content against it.
   cs3.identity.user.v1beta1.UserId user = 4;
   // OPTIONAL An application name if the lock is held by an app.
   string app_name = 5;

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -91,8 +91,8 @@ message ResourceInfo {
   // Arbitrary metadata attached to a resource.
   ArbitraryMetadata arbitrary_metadata = 14;
   // OPTIONAL.
-  // Locks on this resource.
-  repeated Lock locks = 15;
+  // Lock on this resource.
+  Lock lock = 15;
 }
 
 // CanonicalMetadata contains extra metadata
@@ -138,24 +138,15 @@ enum LockType {
 // of this metadata according to their constraints, a reference
 // implementation is given here. The lock SHOULD be stored
 // as an extended attribute on the referenced filesystem entry.
-// It MUST NOT be accessible via the Stat/SetArbitraryMetadata APIs,
-// and it SHOULD contain a base64-encoded JSON with the following format:
-// {
-//   "type" : "<LOCK_TYPE>",
-//   "h" : "<holder>",
-//   "md" : "<metadata>",
-//   "exp" : "<Unix timestamp>"
-// }
+// It MUST NOT be accessible via the Stat/SetArbitraryMetadata APIs.
 message Lock {
   // The type of lock.
   LockType type = 1;
-  // The entity holding the lock.
-  oneof holder {
-    // A userid if the lock is held by a user.
-    cs3.identity.user.v1beta1.UserId user = 2;
-    // An application name if the lock is held by an app.
-    string app_name = 3;
-  }
+  // The entities holding the lock.
+  // REQUIRED. At least one userid of the users participating in the lock.
+  repeated cs3.identity.user.v1beta1.UserId users = 2;
+  // An application name if the lock is held by an app.
+  string app_name = 3;
   // OPTIONAL. Some arbitrary metadata associated with the lock.
   string metadata = 4;
   // OPTIONAL. The time when the lock will expire.


### PR DESCRIPTION
@glpatcern @wkloucek Setting just an mtime does not tell the server when it can release the lock. I propose we use a Timestamp to store the expiration timestamp instead. This would also align better with the WebDAV `Timeout` request header for the LOCK method: http://www.webdav.org/specs/rfc2518.html#rfc.section.9.8

It also allows setting the 30min WOPI timeout, documented as MUST by https://docs.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/concepts#lock and https://docs.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/files/refreshlock