### PR TITLE
Add an optional lock_id argument to storage methods

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -94,11 +94,11 @@ service GatewayAPI {
   // *****************************************************************/
 
   // Creates a new resource of type container.
-  // MUST return CODE_PRECONDITION_FAILED if the container
+  // MUST return CODE_FAILED_PRECONDITION if the container
   // cannot be created at the specified reference.
   rpc CreateContainer(cs3.storage.provider.v1beta1.CreateContainerRequest) returns (cs3.storage.provider.v1beta1.CreateContainerResponse);
   // Creates a new resource of type file.
-  // MUST return CODE_PRECONDITION_FAILED if the file
+  // MUST return CODE_FAILED_PRECONDITION if the file
   // cannot be created at the specified reference.
   rpc TouchFile(cs3.storage.provider.v1beta1.TouchFileRequest) returns (cs3.storage.provider.v1beta1.TouchFileResponse);
   // Deletes a resource.
@@ -143,7 +143,7 @@ service GatewayAPI {
   rpc ListRecycle(cs3.storage.provider.v1beta1.ListRecycleRequest) returns (cs3.storage.provider.v1beta1.ListRecycleResponse);
   // Moves a resource from one reference to another.
   // MUST return CODE_NOT_FOUND if any of the references do not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the source reference
+  // MUST return CODE_FAILED_PRECONDITION if the source reference
   // cannot be moved to the destination reference.
   rpc Move(cs3.storage.provider.v1beta1.MoveRequest) returns (cs3.storage.provider.v1beta1.MoveResponse);
   // Permanently removes a recycle item from the recycle.
@@ -156,7 +156,7 @@ service GatewayAPI {
   rpc RestoreFileVersion(cs3.storage.provider.v1beta1.RestoreFileVersionRequest) returns (cs3.storage.provider.v1beta1.RestoreFileVersionResponse);
   // Restores a recycle item from the recycle.
   // MUST return CODE_NOT_FOUND if the recycle item id does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the restore_path is non-empty
+  // MUST return CODE_FAILED_PRECONDITION if the restore_path is non-empty
   // and the recycle item cannot be restored to the restore_path.
   rpc RestoreRecycleItem(cs3.storage.provider.v1beta1.RestoreRecycleItemRequest) returns (cs3.storage.provider.v1beta1.RestoreRecycleItemResponse);
   // Returns the resource information at the provided reference.
@@ -172,7 +172,7 @@ service GatewayAPI {
   rpc UnsetArbitraryMetadata(cs3.storage.provider.v1beta1.UnsetArbitraryMetadataRequest) returns (cs3.storage.provider.v1beta1.UnsetArbitraryMetadataResponse);
   // Locks a storage resource.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the reference is already locked.
+  // MUST return CODE_FAILED_PRECONDITION if the reference is already locked.
   // In addition, the implementation MUST ensure atomicity when multiple users
   // concurrently attempt to set a lock.
   // The caller MUST have write permissions on the resource.
@@ -183,13 +183,13 @@ service GatewayAPI {
   rpc GetLock(cs3.storage.provider.v1beta1.GetLockRequest) returns (cs3.storage.provider.v1beta1.GetLockResponse);
   // Refreshes the lock metadata of a storage resource.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the reference is not locked
+  // MUST return CODE_FAILED_PRECONDITION if the reference is not locked
   // or if the caller does not hold the lock.
   // The caller MUST have write permissions on the resource.
   rpc RefreshLock(cs3.storage.provider.v1beta1.RefreshLockRequest) returns (cs3.storage.provider.v1beta1.RefreshLockResponse);
   // Unlocks a storage resource.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the reference is not locked
+  // MUST return CODE_FAILED_PRECONDITION if the reference is not locked
   // or if the caller does not hold the lock.
   // The caller MUST have write permissions on the resource.
   rpc Unlock(cs3.storage.provider.v1beta1.UnlockRequest) returns (cs3.storage.provider.v1beta1.UnlockResponse);

--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -527,7 +527,7 @@ message OpenInAppRequest {
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
   // The resource reference. If a path is given, it will be resolved via Stat() to a ResourceInfo
-  // when a call to the WOPI server is to be issued (cf. the provider grpc message)
+  // in case a call to the WOPI server is to be issued (cf. the provider grpc message)
   storage.provider.v1beta1.Reference ref = 2;
   // REQUIRED.
   // View mode.
@@ -547,4 +547,8 @@ message OpenInAppRequest {
   // If the targeted resource is a directory, this parameter is required and
   // in its absence the implementation MUST return INVALID_ARGUMENT.
   string app = 4;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked and the lock type be LOCK_TYPE_EXCL,
+  // the stored lock_id MUST be equal to the given value.
+  string lock_id = 5;
 }

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -214,6 +214,10 @@ message AddGrantRequest {
   // REQUIRED.
   // The grant to be added.
   Grant grant = 3;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message AddGrantResponse {
@@ -235,6 +239,10 @@ message DenyGrantRequest {
   // REQUIRED.
   // The grantee to remove permission.
   Grantee grantee = 3;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message DenyGrantResponse {
@@ -289,6 +297,10 @@ message DeleteRequest {
   // REQUIRED.
   // The reference to which the action should be performed.
   Reference ref = 2;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message DeleteResponse {
@@ -366,6 +378,10 @@ message InitiateFileUploadRequest {
     // return CODE_FAILED_PRECONDITION.
     string if_match = 4;
   }
+  // OPTIONAL.
+  // A lock_id: should the reference exist and be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 5;
 }
 
 message InitiateFileUploadResponse {
@@ -387,6 +403,10 @@ message InitiateFileDownloadRequest {
   // REQUIRED.
   // The reference to which the action should be performed.
   Reference ref = 2;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked and the lock type be LOCK_TYPE_EXCL,
+  // the stored lock_id MUST be equal to the given value.
+  string lock_id = 3;
 }
 
 message InitiateFileDownloadResponse {
@@ -573,6 +593,10 @@ message MoveRequest {
   // REQUIRED.
   // The destination reference the resource is moved to.
   Reference destination = 3;
+  // OPTIONAL.
+  // A lock_id: should the source reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message MoveResponse {
@@ -665,6 +689,10 @@ message RemoveGrantRequest {
   // REQUIRED.
   // The grant to remove.
   Grant grant = 3;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked and the lock be exclusive,
+  // the stored lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message RemoveGrantResponse {
@@ -711,6 +739,10 @@ message UpdateGrantRequest {
   // REQUIRED.
   // The grant to be updated.
   Grant grant = 3;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked and the lock be exclusive,
+  // the stored lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message UpdateGrantResponse {
@@ -775,6 +807,10 @@ message SetArbitraryMetadataRequest {
   // REQUIRED.
   // The arbitrary metadata to add to the resource.
   ArbitraryMetadata arbitrary_metadata = 3;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message SetArbitraryMetadataResponse {
@@ -796,6 +832,10 @@ message UnsetArbitraryMetadataRequest {
   // REQUIRED.
   // The arbitrary metadata to delete.
   repeated string arbitrary_metadata_keys = 3;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message UnsetArbitraryMetadataResponse {

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -148,7 +148,8 @@ service ProviderAPI {
   // Unsets arbitrary metdata into a storage resource.
   // Arbitrary metadata is returned in a cs3.storageprovider.v1beta1.ResourceInfo.
   rpc UnsetArbitraryMetadata(UnsetArbitraryMetadataRequest) returns (UnsetArbitraryMetadataResponse);
-  // Locks a storage resource.
+  // Locks a storage resource. Note that if the resource is a container,
+  // MAY return CODE_NOT_IMPLEMENTED as the behavior is yet to be defined at this stage.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
   // MUST return CODE_FAILED_PRECONDITION if the reference is already locked.
   // In addition, the implementation MUST ensure atomicity when multiple users
@@ -450,7 +451,7 @@ message ListContainerStreamRequest {
   // The reference to which the action should be performed.
   Reference ref = 2;
   // OPTIONAL.
-  // Arbitrary metadata be included with the resource.
+  // Arbitrary metadata to be included with the resource.
   // A key with the name '*' means to return all available arbitrary metadata.
   repeated string arbitrary_metadata_keys = 3;
 }
@@ -475,7 +476,7 @@ message ListContainerRequest {
   // The reference to which the action should be performed.
   Reference ref = 2;
   // OPTIONAL.
-  // Arbitrary metadata be included with the resource.
+  // Arbitrary metadata to be included with the resource.
   // A key with the name '*' means to return all available arbitrary metadata.
   repeated string arbitrary_metadata_keys = 3;
 }

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -639,6 +639,10 @@ message RestoreFileVersionRequest {
   // REQUIRED.
   // The key to restore a specific file version.
   string key = 3;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 4;
 }
 
 message RestoreFileVersionResponse {
@@ -668,6 +672,10 @@ message RestoreRecycleItemRequest {
   // If empty, service implementors MUST restore
   // to original location if possible.
   Reference restore_ref = 4;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
+  string lock_id = 5;
 }
 
 message RestoreRecycleItemResponse {
@@ -690,8 +698,8 @@ message RemoveGrantRequest {
   // The grant to remove.
   Grant grant = 3;
   // OPTIONAL.
-  // A lock_id: should the reference be locked and the lock be exclusive,
-  // the stored lock_id MUST be equal to the given value.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
   string lock_id = 4;
 }
 
@@ -740,8 +748,8 @@ message UpdateGrantRequest {
   // The grant to be updated.
   Grant grant = 3;
   // OPTIONAL.
-  // A lock_id: should the reference be locked and the lock be exclusive,
-  // the stored lock_id MUST be equal to the given value.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value.
   string lock_id = 4;
 }
 

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -54,11 +54,11 @@ service ProviderAPI {
   // MUST return CODE_NOT_FOUND if the reference does not exist
   rpc AddGrant(AddGrantRequest) returns (AddGrantResponse);
   // Creates a new resource of type container.
-  // MUST return CODE_PRECONDITION_FAILED if the container
+  // MUST return CODE_FAILED_PRECONDITION if the container
   // cannot be created at the specified reference.
   rpc CreateContainer(CreateContainerRequest) returns (CreateContainerResponse);
   // Creates a new resource of type file.
-  // MUST return CODE_PRECONDITION_FAILED if the file
+  // MUST return CODE_FAILED_PRECONDITION if the file
   // cannot be created at the specified reference.
   rpc TouchFile(TouchFileRequest) returns (TouchFileResponse);
   // Deletes a resource.
@@ -109,7 +109,7 @@ service ProviderAPI {
   rpc ListRecycle(ListRecycleRequest) returns (ListRecycleResponse);
   // Moves a resource from one reference to another.
   // MUST return CODE_NOT_FOUND if any of the references do not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the source reference
+  // MUST return CODE_FAILED_PRECONDITION if the source reference
   // cannot be moved to the destination reference.
   rpc Move(MoveRequest) returns (MoveResponse);
   // Removes a grant for the provided reference.
@@ -127,7 +127,7 @@ service ProviderAPI {
   rpc RestoreFileVersion(RestoreFileVersionRequest) returns (RestoreFileVersionResponse);
   // Restores a recycle item from the recycle.
   // MUST return CODE_NOT_FOUND if the recycle item id does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the restore_path is non-empty
+  // MUST return CODE_FAILED_PRECONDITION if the restore_path is non-empty
   // and the recycle item cannot be restored to the restore_path.
   rpc RestoreRecycleItem(RestoreRecycleItemRequest) returns (RestoreRecycleItemResponse);
   // Returns the resource information at the provided reference.
@@ -135,7 +135,7 @@ service ProviderAPI {
   rpc Stat(StatRequest) returns (StatResponse);
   // Updates an ACL for the provided reference.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the acl does not exist.
+  // MUST return CODE_FAILED_PRECONDITION if the acl does not exist.
   rpc UpdateGrant(UpdateGrantRequest) returns (UpdateGrantResponse);
   // Creates a symlink to another resource.
   rpc CreateSymlink(CreateSymlinkRequest) returns (CreateSymlinkResponse);
@@ -150,7 +150,7 @@ service ProviderAPI {
   rpc UnsetArbitraryMetadata(UnsetArbitraryMetadataRequest) returns (UnsetArbitraryMetadataResponse);
   // Locks a storage resource.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the reference is already locked.
+  // MUST return CODE_FAILED_PRECONDITION if the reference is already locked.
   // In addition, the implementation MUST ensure atomicity when multiple users
   // concurrently attempt to set a lock.
   // The caller MUST have write permissions on the resource.
@@ -167,7 +167,7 @@ service ProviderAPI {
   rpc RefreshLock(RefreshLockRequest) returns (RefreshLockResponse);
   // Unlocks a storage resource.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  // MUST return CODE_PRECONDITION_FAILED if the reference is not locked
+  // MUST return CODE_FAILED_PRECONDITION if the reference is not locked
   // or if the caller does not hold the lock.
   // The caller MUST have write permissions on the resource.
   rpc Unlock(UnlockRequest) returns (UnlockResponse);

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -300,7 +300,7 @@ message DeleteRequest {
   // OPTIONAL.
   // A lock_id: should the reference be locked, the stored
   // lock_id MUST be equal to the given value.
-  string lock_id = 4;
+  string lock_id = 3;
 }
 
 message DeleteResponse {
@@ -673,8 +673,8 @@ message RestoreRecycleItemRequest {
   // to original location if possible.
   Reference restore_ref = 4;
   // OPTIONAL.
-  // A lock_id: should the reference be locked, the stored
-  // lock_id MUST be equal to the given value.
+  // A lock_id: should a lock exist for the reference where the file is
+  // to be restored, the stored lock_id MUST be equal to the given value.
   string lock_id = 5;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -13343,6 +13343,15 @@ The reference to which the action should be performed. </p></td>
 The grant to be added. </p></td>
                 </tr>
               
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -13407,6 +13416,15 @@ Opaque information. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The reference to which the action should be performed. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -13777,6 +13795,15 @@ Opaque information. </p></td>
 The reference to which the action should be performed. </p></td>
                 </tr>
               
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked and the lock type be LOCK_TYPE_EXCL,
+the stored lock_id MUST be equal to the given value. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -13914,6 +13941,15 @@ The reference to which the action should be performed. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The grantee to remove permission. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -14373,6 +14409,15 @@ The request MUST return CODE_NOT_IMPLEMENTED if the provider does not support th
 Whether the file is to be uploaded if the given etag matches. Default to always upload.
 If the storage provider has a more recent etag for the target file, the request MUST
 return CODE_FAILED_PRECONDITION. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference exist and be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -15095,6 +15140,15 @@ The source reference the resource is moved from. </p></td>
 The destination reference the resource is moved to. </p></td>
                 </tr>
               
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the source reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -15315,6 +15369,15 @@ The reference to which the action should be performed. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The grant to remove. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked and the lock be exclusive,
+the stored lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -15549,6 +15612,15 @@ The reference to which the action should be performed. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The arbitrary metadata to add to the resource. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -15923,6 +15995,15 @@ The reference to which the action should be performed. </p></td>
 The arbitrary metadata to delete. </p></td>
                 </tr>
               
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -15995,6 +16076,15 @@ The reference to which the action should be performed. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The grant to be updated. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked and the lock be exclusive,
+the stored lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -15563,8 +15563,8 @@ to original location if possible. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-A lock_id: should the reference be locked, the stored
-lock_id MUST be equal to the given value. </p></td>
+A lock_id: should a lock exist for the reference where the file is
+to be restored, the stored lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2317,7 +2317,7 @@ Opaque information. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The resource reference. If a path is given, it will be resolved via Stat() to a ResourceInfo
-when a call to the WOPI server is to be issued (cf. the provider grpc message) </p></td>
+in case a call to the WOPI server is to be issued (cf. the provider grpc message) </p></td>
                 </tr>
               
                 <tr>
@@ -2336,6 +2336,15 @@ A reference to the application to be used to open the resource, should the
 default inferred from the resource&#39;s mimetype be overridden by user&#39;s choice.
 If the targeted resource is a directory, this parameter is required and
 in its absence the implementation MUST return INVALID_ARGUMENT. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked and the lock type be LOCK_TYPE_EXCL,
+the stored lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -13418,15 +13427,6 @@ Opaque information. </p></td>
 The reference to which the action should be performed. </p></td>
                 </tr>
               
-                <tr>
-                  <td>lock_id</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>OPTIONAL.
-A lock_id: should the reference be locked, the stored
-lock_id MUST be equal to the given value. </p></td>
-                </tr>
-              
             </tbody>
           </table>
 
@@ -13800,8 +13800,8 @@ The reference to which the action should be performed. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-A lock_id: should the reference be locked and the lock type be LOCK_TYPE_EXCL,
-the stored lock_id MUST be equal to the given value. </p></td>
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -14313,6 +14313,15 @@ Opaque information. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The reference to which the action should be performed. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked and the lock type be LOCK_TYPE_EXCL,
+the stored lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -15376,8 +15385,8 @@ The grant to remove. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-A lock_id: should the reference be locked and the lock be exclusive,
-the stored lock_id MUST be equal to the given value. </p></td>
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -15452,6 +15461,15 @@ The reference to which the action should be performed. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The key to restore a specific file version. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -15538,6 +15556,15 @@ It can be useful to restore to another location rather than
 the original.
 If empty, service implementors MUST restore
 to original location if possible. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>
@@ -16083,8 +16110,8 @@ The grant to be updated. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-A lock_id: should the reference be locked and the lock be exclusive,
-the stored lock_id MUST be equal to the given value. </p></td>
+A lock_id: should the reference be locked, the stored
+lock_id MUST be equal to the given value. </p></td>
                 </tr>
               
             </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2533,7 +2533,7 @@ third-party applications.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.CreateContainerRequest">.cs3.storage.provider.v1beta1.CreateContainerRequest</a></td>
                 <td><a href="#cs3.storage.provider.v1beta1.CreateContainerResponse">.cs3.storage.provider.v1beta1.CreateContainerResponse</a></td>
                 <td><p>Creates a new resource of type container.
-MUST return CODE_PRECONDITION_FAILED if the container
+MUST return CODE_FAILED_PRECONDITION if the container
 cannot be created at the specified reference.</p></td>
               </tr>
             
@@ -2542,7 +2542,7 @@ cannot be created at the specified reference.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.TouchFileRequest">.cs3.storage.provider.v1beta1.TouchFileRequest</a></td>
                 <td><a href="#cs3.storage.provider.v1beta1.TouchFileResponse">.cs3.storage.provider.v1beta1.TouchFileResponse</a></td>
                 <td><p>Creates a new resource of type file.
-MUST return CODE_PRECONDITION_FAILED if the file
+MUST return CODE_FAILED_PRECONDITION if the file
 cannot be created at the specified reference.</p></td>
               </tr>
             
@@ -2642,7 +2642,7 @@ MUST return CODE_OK and MUST return an empty list if no recycle items are availa
                 <td><a href="#cs3.storage.provider.v1beta1.MoveResponse">.cs3.storage.provider.v1beta1.MoveResponse</a></td>
                 <td><p>Moves a resource from one reference to another.
 MUST return CODE_NOT_FOUND if any of the references do not exist.
-MUST return CODE_PRECONDITION_FAILED if the source reference
+MUST return CODE_FAILED_PRECONDITION if the source reference
 cannot be moved to the destination reference.</p></td>
               </tr>
             
@@ -2670,7 +2670,7 @@ MUST return CODE_NOT_FOUND if the version does not exist.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.RestoreRecycleItemResponse">.cs3.storage.provider.v1beta1.RestoreRecycleItemResponse</a></td>
                 <td><p>Restores a recycle item from the recycle.
 MUST return CODE_NOT_FOUND if the recycle item id does not exist.
-MUST return CODE_PRECONDITION_FAILED if the restore_path is non-empty
+MUST return CODE_FAILED_PRECONDITION if the restore_path is non-empty
 and the recycle item cannot be restored to the restore_path.</p></td>
               </tr>
             
@@ -2711,7 +2711,7 @@ Arbitrary metadata is returned in a cs3.storage.provider.v1beta1.ResourceInfo.</
                 <td><a href="#cs3.storage.provider.v1beta1.SetLockResponse">.cs3.storage.provider.v1beta1.SetLockResponse</a></td>
                 <td><p>Locks a storage resource.
 MUST return CODE_NOT_FOUND if the reference does not exist.
-MUST return CODE_PRECONDITION_FAILED if the reference is already locked.
+MUST return CODE_FAILED_PRECONDITION if the reference is already locked.
 In addition, the implementation MUST ensure atomicity when multiple users
 concurrently attempt to set a lock.
 The caller MUST have write permissions on the resource.</p></td>
@@ -2732,7 +2732,7 @@ The caller MUST have read permissions on the resource.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.RefreshLockResponse">.cs3.storage.provider.v1beta1.RefreshLockResponse</a></td>
                 <td><p>Refreshes the lock metadata of a storage resource.
 MUST return CODE_NOT_FOUND if the reference does not exist.
-MUST return CODE_PRECONDITION_FAILED if the reference is not locked
+MUST return CODE_FAILED_PRECONDITION if the reference is not locked
 or if the caller does not hold the lock.
 The caller MUST have write permissions on the resource.</p></td>
               </tr>
@@ -2743,7 +2743,7 @@ The caller MUST have write permissions on the resource.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.UnlockResponse">.cs3.storage.provider.v1beta1.UnlockResponse</a></td>
                 <td><p>Unlocks a storage resource.
 MUST return CODE_NOT_FOUND if the reference does not exist.
-MUST return CODE_PRECONDITION_FAILED if the reference is not locked
+MUST return CODE_FAILED_PRECONDITION if the reference is not locked
 or if the caller does not hold the lock.
 The caller MUST have write permissions on the resource.</p></td>
               </tr>
@@ -16295,7 +16295,7 @@ MUST return CODE_NOT_FOUND if the reference does not exist</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.CreateContainerRequest">CreateContainerRequest</a></td>
                 <td><a href="#cs3.storage.provider.v1beta1.CreateContainerResponse">CreateContainerResponse</a></td>
                 <td><p>Creates a new resource of type container.
-MUST return CODE_PRECONDITION_FAILED if the container
+MUST return CODE_FAILED_PRECONDITION if the container
 cannot be created at the specified reference.</p></td>
               </tr>
             
@@ -16304,7 +16304,7 @@ cannot be created at the specified reference.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.TouchFileRequest">TouchFileRequest</a></td>
                 <td><a href="#cs3.storage.provider.v1beta1.TouchFileResponse">TouchFileResponse</a></td>
                 <td><p>Creates a new resource of type file.
-MUST return CODE_PRECONDITION_FAILED if the file
+MUST return CODE_FAILED_PRECONDITION if the file
 cannot be created at the specified reference.</p></td>
               </tr>
             
@@ -16420,7 +16420,7 @@ MUST return CODE_OK and MUST return an empty list if no recycle items are availa
                 <td><a href="#cs3.storage.provider.v1beta1.MoveResponse">MoveResponse</a></td>
                 <td><p>Moves a resource from one reference to another.
 MUST return CODE_NOT_FOUND if any of the references do not exist.
-MUST return CODE_PRECONDITION_FAILED if the source reference
+MUST return CODE_FAILED_PRECONDITION if the source reference
 cannot be moved to the destination reference.</p></td>
               </tr>
             
@@ -16458,7 +16458,7 @@ MUST return CODE_NOT_FOUND if the version does not exist.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.RestoreRecycleItemResponse">RestoreRecycleItemResponse</a></td>
                 <td><p>Restores a recycle item from the recycle.
 MUST return CODE_NOT_FOUND if the recycle item id does not exist.
-MUST return CODE_PRECONDITION_FAILED if the restore_path is non-empty
+MUST return CODE_FAILED_PRECONDITION if the restore_path is non-empty
 and the recycle item cannot be restored to the restore_path.</p></td>
               </tr>
             
@@ -16476,7 +16476,7 @@ MUST return CODE_NOT_FOUND if the reference does not exist.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.UpdateGrantResponse">UpdateGrantResponse</a></td>
                 <td><p>Updates an ACL for the provided reference.
 MUST return CODE_NOT_FOUND if the reference does not exist.
-MUST return CODE_PRECONDITION_FAILED if the acl does not exist.</p></td>
+MUST return CODE_FAILED_PRECONDITION if the acl does not exist.</p></td>
               </tr>
             
               <tr>
@@ -16516,7 +16516,7 @@ Arbitrary metadata is returned in a cs3.storageprovider.v1beta1.ResourceInfo.</p
                 <td><a href="#cs3.storage.provider.v1beta1.SetLockResponse">SetLockResponse</a></td>
                 <td><p>Locks a storage resource.
 MUST return CODE_NOT_FOUND if the reference does not exist.
-MUST return CODE_PRECONDITION_FAILED if the reference is already locked.
+MUST return CODE_FAILED_PRECONDITION if the reference is already locked.
 In addition, the implementation MUST ensure atomicity when multiple users
 concurrently attempt to set a lock.
 The caller MUST have write permissions on the resource.</p></td>
@@ -16548,7 +16548,7 @@ The caller MUST have write permissions on the resource.</p></td>
                 <td><a href="#cs3.storage.provider.v1beta1.UnlockResponse">UnlockResponse</a></td>
                 <td><p>Unlocks a storage resource.
 MUST return CODE_NOT_FOUND if the reference does not exist.
-MUST return CODE_PRECONDITION_FAILED if the reference is not locked
+MUST return CODE_FAILED_PRECONDITION if the reference is not locked
 or if the caller does not hold the lock.
 The caller MUST have write permissions on the resource.</p></td>
               </tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14508,7 +14508,7 @@ The reference to which the action should be performed. </p></td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
                   <td><p>OPTIONAL.
-Arbitrary metadata be included with the resource.
+Arbitrary metadata to be included with the resource.
 A key with the name &#39;*&#39; means to return all available arbitrary metadata. </p></td>
                 </tr>
               
@@ -14591,7 +14591,7 @@ The reference to which the action should be performed. </p></td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
                   <td><p>OPTIONAL.
-Arbitrary metadata be included with the resource.
+Arbitrary metadata to be included with the resource.
 A key with the name &#39;*&#39; means to return all available arbitrary metadata. </p></td>
                 </tr>
               
@@ -16514,7 +16514,8 @@ Arbitrary metadata is returned in a cs3.storageprovider.v1beta1.ResourceInfo.</p
                 <td>SetLock</td>
                 <td><a href="#cs3.storage.provider.v1beta1.SetLockRequest">SetLockRequest</a></td>
                 <td><a href="#cs3.storage.provider.v1beta1.SetLockResponse">SetLockResponse</a></td>
-                <td><p>Locks a storage resource.
+                <td><p>Locks a storage resource. Note that if the resource is a container,
+MAY return CODE_NOT_IMPLEMENTED as the behavior is yet to be defined at this stage.
 MUST return CODE_NOT_FOUND if the reference does not exist.
 MUST return CODE_FAILED_PRECONDITION if the reference is already locked.
 In addition, the implementation MUST ensure atomicity when multiple users


### PR DESCRIPTION
Follow up of cs3org/cs3apis#162: the storage methods that modify a resource now have an optional `lock_id` argument, such that storage provider implementations can enforce the lock validation.

In addition, also the `InitiateDownloadRequest` has this extra argument, in order to honor exclusive locks. The assumption then is that stat and metadata read operations are always allowed (when access rights are met), such that e.g. the web UI can show users that "File important_stuff.txt is locked in exclusive mode by user bob".