### PR TITLE
Match multiple providers in auth registry

### DIFF
--- a/cs3/auth/registry/v1beta1/registry_api.proto
+++ b/cs3/auth/registry/v1beta1/registry_api.proto
@@ -53,12 +53,12 @@ service RegistryAPI {
   // Returns the auth provider that is reponsible for the given
   // resource reference.
   // MUST return CODE_NOT_FOUND if the reference does not exist.
-  rpc GetAuthProvider(GetAuthProviderRequest) returns (GetAuthProviderResponse);
+  rpc GetAuthProviders(GetAuthProvidersRequest) returns (GetAuthProvidersResponse);
   // Returns a list of the available auth providers known by this registry.
   rpc ListAuthProviders(ListAuthProvidersRequest) returns (ListAuthProvidersResponse);
 }
 
-message GetAuthProviderRequest {
+message GetAuthProvidersRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
@@ -67,7 +67,7 @@ message GetAuthProviderRequest {
   string type = 2;
 }
 
-message GetAuthProviderResponse {
+message GetAuthProvidersResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -75,8 +75,8 @@ message GetAuthProviderResponse {
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
-  // The auth provider handling the requested auth call.
-  ProviderInfo provider = 3;
+  // The auth providers handling the requested auth call.
+  repeated ProviderInfo providers = 3;
 }
 
 message ListAuthProvidersRequest {

--- a/docs/index.html
+++ b/docs/index.html
@@ -423,10 +423,6 @@
                   <a href="#cs3.tx.v1beta1.ListTransfersRequest.Filter.Type"><span class="badge">E</span>ListTransfersRequest.Filter.Type</a>
                 </li>
               
-                <li>
-                  <a href="#cs3.tx.v1beta1.ListTransfersRequest.Filter.Type"><span class="badge">E</span>ListTransfersRequest.Filter.Type</a>
-                </li>
-              
               
               
                 <li>
@@ -799,11 +795,11 @@
             <ul>
               
                 <li>
-                  <a href="#cs3.auth.registry.v1beta1.GetAuthProviderRequest"><span class="badge">M</span>GetAuthProviderRequest</a>
+                  <a href="#cs3.auth.registry.v1beta1.GetAuthProvidersRequest"><span class="badge">M</span>GetAuthProvidersRequest</a>
                 </li>
               
                 <li>
-                  <a href="#cs3.auth.registry.v1beta1.GetAuthProviderResponse"><span class="badge">M</span>GetAuthProviderResponse</a>
+                  <a href="#cs3.auth.registry.v1beta1.GetAuthProvidersResponse"><span class="badge">M</span>GetAuthProvidersResponse</a>
                 </li>
               
                 <li>
@@ -3248,18 +3244,7 @@ MUST return CODE_NOT_FOUND if the sync&#39;n&#39;share system provider does not 
                 <td>CancelTransfer</td>
                 <td><a href="#cs3.tx.v1beta1.CancelTransferRequest">.cs3.tx.v1beta1.CancelTransferRequest</a></td>
                 <td><a href="#cs3.tx.v1beta1.CancelTransferResponse">.cs3.tx.v1beta1.CancelTransferResponse</a></td>
-                <td><p>Requests to cancel a transfer.
-
-*****************************************************************/
-************************** Permissions **************************/
-*****************************************************************/</p></td>
-              </tr>
-            
-              <tr>
-                <td>CheckPermission</td>
-                <td><a href="#cs3.permissions.v1beta1.CheckPermissionRequest">.cs3.permissions.v1beta1.CheckPermissionRequest</a></td>
-                <td><a href="#cs3.permissions.v1beta1.CheckPermissionResponse">.cs3.permissions.v1beta1.CheckPermissionResponse</a></td>
-                <td><p>CheckPermission checks if a user or group has a certain permission.</p></td>
+                <td><p>Requests to cancel a transfer.</p></td>
               </tr>
             
               <tr>
@@ -3273,7 +3258,18 @@ MUST return CODE_NOT_FOUND if the sync&#39;n&#39;share system provider does not 
                 <td>RetryTransfer</td>
                 <td><a href="#cs3.tx.v1beta1.RetryTransferRequest">.cs3.tx.v1beta1.RetryTransferRequest</a></td>
                 <td><a href="#cs3.tx.v1beta1.RetryTransferResponse">.cs3.tx.v1beta1.RetryTransferResponse</a></td>
-                <td><p>Requests retrying a transfer.</p></td>
+                <td><p>Requests retrying a transfer.
+
+*****************************************************************/
+************************** Permissions **************************/
+*****************************************************************/</p></td>
+              </tr>
+            
+              <tr>
+                <td>CheckPermission</td>
+                <td><a href="#cs3.permissions.v1beta1.CheckPermissionRequest">.cs3.permissions.v1beta1.CheckPermissionRequest</a></td>
+                <td><a href="#cs3.permissions.v1beta1.CheckPermissionResponse">.cs3.permissions.v1beta1.CheckPermissionResponse</a></td>
+                <td><p>CheckPermission checks if a user or group has a certain permission.</p></td>
               </tr>
             
           </tbody>
@@ -7183,7 +7179,7 @@ The role associated with the resource. </p></td>
       <p></p>
 
       
-        <h3 id="cs3.auth.registry.v1beta1.GetAuthProviderRequest">GetAuthProviderRequest</h3>
+        <h3 id="cs3.auth.registry.v1beta1.GetAuthProvidersRequest">GetAuthProvidersRequest</h3>
         <p></p>
 
         
@@ -7216,7 +7212,7 @@ The type of authentication provider. </p></td>
 
         
       
-        <h3 id="cs3.auth.registry.v1beta1.GetAuthProviderResponse">GetAuthProviderResponse</h3>
+        <h3 id="cs3.auth.registry.v1beta1.GetAuthProvidersResponse">GetAuthProvidersResponse</h3>
         <p></p>
 
         
@@ -7243,11 +7239,11 @@ Opaque information. </p></td>
                 </tr>
               
                 <tr>
-                  <td>provider</td>
+                  <td>providers</td>
                   <td><a href="#cs3.auth.registry.v1beta1.ProviderInfo">ProviderInfo</a></td>
-                  <td></td>
+                  <td>repeated</td>
                   <td><p>REQUIRED.
-The auth provider handling the requested auth call. </p></td>
+The auth providers handling the requested auth call. </p></td>
                 </tr>
               
             </tbody>
@@ -7340,9 +7336,9 @@ The list of auth providers this registry knows about. </p></td>
           <tbody>
             
               <tr>
-                <td>GetAuthProvider</td>
-                <td><a href="#cs3.auth.registry.v1beta1.GetAuthProviderRequest">GetAuthProviderRequest</a></td>
-                <td><a href="#cs3.auth.registry.v1beta1.GetAuthProviderResponse">GetAuthProviderResponse</a></td>
+                <td>GetAuthProviders</td>
+                <td><a href="#cs3.auth.registry.v1beta1.GetAuthProvidersRequest">GetAuthProvidersRequest</a></td>
+                <td><a href="#cs3.auth.registry.v1beta1.GetAuthProvidersResponse">GetAuthProvidersResponse</a></td>
                 <td><p>Returns the auth provider that is reponsible for the given
 resource reference.
 MUST return CODE_NOT_FOUND if the reference does not exist.</p></td>
@@ -15845,6 +15841,14 @@ Opaque information. </p></td>
 The reference the lock is associated to. </p></td>
                 </tr>
               
+                <tr>
+                  <td>lock</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Lock">Lock</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The lock metadata. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -16822,7 +16826,7 @@ Opaque information such as UID or GID. </p></td>
         
       
         <h3 id="cs3.storage.provider.v1beta1.Lock">Lock</h3>
-        <p>The metadata associated with a lock on a resource.</p><p>Provided that storage drivers are free to implement the storage</p><p>of this metadata according to their constraints, a reference</p><p>implementation is given here. The lock SHOULD be stored</p><p>as an extended attribute on the referenced filesystem entry.</p><p>It MUST NOT be accessible via the Stat/SetArbitraryMetadata APIs,</p><p>and it SHOULD contain a base64-encoded JSON with the following format:</p><p>{</p><p>"type" : "<LOCK_TYPE>",</p><p>"h" : "<holder>",</p><p>"md" : "<metadata>",</p><p>"mtime" : "<Unix timestamp>"</p><p>}</p>
+        <p>The metadata associated with a lock on a resource.</p><p>Provided that storage drivers are free to implement the storage</p><p>of this metadata according to their constraints, a reference</p><p>implementation is given here. The lock SHOULD be stored</p><p>as an extended attribute on the referenced filesystem entry.</p><p>Such extended attribute MUST NOT be exposed via the `Stat` and `SetArbitraryMetadata` APIs.</p><p>Instead, the `ResourceInfo.Lock` attribute MUST be populated if a lock exists for the given reference.</p>
 
         
           <table class="field-table">
@@ -16832,39 +16836,53 @@ Opaque information such as UID or GID. </p></td>
             <tbody>
               
                 <tr>
+                  <td>opaque</td>
+                  <td><a href="#cs3.types.v1beta1.Opaque">cs3.types.v1beta1.Opaque</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The id of the lock, eg. the X-WOPI-Lock id or the WebDAV opaquelocktoken. </p></td>
+                </tr>
+              
+                <tr>
                   <td>type</td>
                   <td><a href="#cs3.storage.provider.v1beta1.LockType">LockType</a></td>
                   <td></td>
-                  <td><p>The type of lock. </p></td>
+                  <td><p>REQUIRED.
+The type of lock. </p></td>
                 </tr>
               
                 <tr>
                   <td>user</td>
                   <td><a href="#cs3.identity.user.v1beta1.UserId">cs3.identity.user.v1beta1.UserId</a></td>
                   <td></td>
-                  <td><p>A userid if the lock is held by a user. </p></td>
+                  <td><p>OPTIONAL.
+The userid of a user, which represents either the lock holder, or the user that last created/modified the lock.
+When non empty, `RefreshLock` and `Unlock` operations MUST check their request&#39;s content against it. </p></td>
                 </tr>
               
                 <tr>
                   <td>app_name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>An application name if the lock is held by an app. </p></td>
+                  <td><p>OPTIONAL.
+An application name if the lock is held by an app.
+When non empty, `RefreshLock` and `Unlock` operations MUST check their request&#39;s content against it. </p></td>
                 </tr>
               
                 <tr>
-                  <td>metadata</td>
-                  <td><a href="#string">string</a></td>
-                  <td></td>
-                  <td><p>Some arbitrary metadata associated with the lock. </p></td>
-                </tr>
-              
-                <tr>
-                  <td>mtime</td>
+                  <td>expiration</td>
                   <td><a href="#cs3.types.v1beta1.Timestamp">cs3.types.v1beta1.Timestamp</a></td>
                   <td></td>
-                  <td><p>The last modification time of the lock.
-The value is Unix Epoch timestamp in seconds. </p></td>
+                  <td><p>OPTIONAL.
+The time when the lock will expire. </p></td>
                 </tr>
               
             </tbody>
@@ -17254,6 +17272,22 @@ be specified. </p></td>
                   <td></td>
                   <td><p>OPTIONAL.
 Arbitrary metadata attached to a resource. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lock</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Lock">Lock</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Exclusive or write lock on this resource that will limit modification of the resource to holders of the lock. Can be used by WOPI or other apps requiring exclusive locks. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>advisory_locks</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.Lock">Lock</a></td>
+                  <td>repeated</td>
+                  <td><p>OPTIONAL.
+Advisory locks on this resource. Can be used for shared locks or other forms of collaborative locks. </p></td>
                 </tr>
               
             </tbody>

--- a/proto.lock
+++ b/proto.lock
@@ -1549,7 +1549,7 @@
       "def": {
         "messages": [
           {
-            "name": "GetAuthProviderRequest",
+            "name": "GetAuthProvidersRequest",
             "fields": [
               {
                 "id": 1,
@@ -1564,7 +1564,7 @@
             ]
           },
           {
-            "name": "GetAuthProviderResponse",
+            "name": "GetAuthProvidersResponse",
             "fields": [
               {
                 "id": 1,
@@ -1578,8 +1578,9 @@
               },
               {
                 "id": 3,
-                "name": "provider",
-                "type": "ProviderInfo"
+                "name": "providers",
+                "type": "ProviderInfo",
+                "is_repeated": true
               }
             ]
           },
@@ -1620,9 +1621,9 @@
             "name": "RegistryAPI",
             "rpcs": [
               {
-                "name": "GetAuthProvider",
-                "in_type": "GetAuthProviderRequest",
-                "out_type": "GetAuthProviderResponse"
+                "name": "GetAuthProviders",
+                "in_type": "GetAuthProvidersRequest",
+                "out_type": "GetAuthProvidersResponse"
               },
               {
                 "name": "ListAuthProviders",
@@ -2003,6 +2004,11 @@
                 "out_type": "cs3.storage.provider.v1beta1.CreateContainerResponse"
               },
               {
+                "name": "TouchFile",
+                "in_type": "cs3.storage.provider.v1beta1.TouchFileRequest",
+                "out_type": "cs3.storage.provider.v1beta1.TouchFileResponse"
+              },
+              {
                 "name": "Delete",
                 "in_type": "cs3.storage.provider.v1beta1.DeleteRequest",
                 "out_type": "cs3.storage.provider.v1beta1.DeleteResponse"
@@ -2093,6 +2099,26 @@
                 "name": "UnsetArbitraryMetadata",
                 "in_type": "cs3.storage.provider.v1beta1.UnsetArbitraryMetadataRequest",
                 "out_type": "cs3.storage.provider.v1beta1.UnsetArbitraryMetadataResponse"
+              },
+              {
+                "name": "SetLock",
+                "in_type": "cs3.storage.provider.v1beta1.SetLockRequest",
+                "out_type": "cs3.storage.provider.v1beta1.SetLockResponse"
+              },
+              {
+                "name": "GetLock",
+                "in_type": "cs3.storage.provider.v1beta1.GetLockRequest",
+                "out_type": "cs3.storage.provider.v1beta1.GetLockResponse"
+              },
+              {
+                "name": "RefreshLock",
+                "in_type": "cs3.storage.provider.v1beta1.RefreshLockRequest",
+                "out_type": "cs3.storage.provider.v1beta1.RefreshLockResponse"
+              },
+              {
+                "name": "Unlock",
+                "in_type": "cs3.storage.provider.v1beta1.UnlockRequest",
+                "out_type": "cs3.storage.provider.v1beta1.UnlockResponse"
               },
               {
                 "name": "CreateHome",
@@ -2398,6 +2424,11 @@
                 "name": "RetryTransfer",
                 "in_type": "cs3.tx.v1beta1.RetryTransferRequest",
                 "out_type": "cs3.tx.v1beta1.RetryTransferResponse"
+              },
+              {
+                "name": "CheckPermission",
+                "in_type": "cs3.permissions.v1beta1.CheckPermissionRequest",
+                "out_type": "cs3.permissions.v1beta1.CheckPermissionResponse"
               }
             ]
           }
@@ -2435,6 +2466,9 @@
           },
           {
             "path": "cs3/ocm/provider/v1beta1/provider_api.proto"
+          },
+          {
+            "path": "cs3/permissions/v1beta1/permissions_api.proto"
           },
           {
             "path": "cs3/preferences/v1beta1/preferences_api.proto"
@@ -4255,6 +4289,162 @@
           {
             "name": "php_namespace",
             "value": "Cs3\\\\Ocm\\\\Provider\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "cs3:/:permissions:/:v1beta1:/:permissions_api.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "CheckPermissionRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "permission",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "subject_ref",
+                "type": "cs3.permissions.v1beta1.SubjectReference"
+              },
+              {
+                "id": 3,
+                "name": "ref",
+                "type": "cs3.storage.provider.v1beta1.Reference"
+              }
+            ]
+          },
+          {
+            "name": "CheckPermissionResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "PermissionsAPI",
+            "rpcs": [
+              {
+                "name": "CheckPermission",
+                "in_type": "CheckPermissionRequest",
+                "out_type": "CheckPermissionResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "cs3/permissions/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/rpc/v1beta1/status.proto"
+          },
+          {
+            "path": "cs3/storage/provider/v1beta1/resources.proto"
+          }
+        ],
+        "package": {
+          "name": "cs3.permissions.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Permissions.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "permissionsv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "PermissionsApiProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.permissions.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CPX"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Permissions\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "cs3:/:permissions:/:v1beta1:/:resources.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "SubjectReference",
+            "fields": [
+              {
+                "id": 1,
+                "name": "user_id",
+                "type": "cs3.identity.user.v1beta1.UserId"
+              },
+              {
+                "id": 2,
+                "name": "group_id",
+                "type": "cs3.identity.group.v1beta1.GroupId"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "cs3/identity/group/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/identity/user/v1beta1/resources.proto"
+          }
+        ],
+        "package": {
+          "name": "cs3.permissions.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Permissions.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "permissionsv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ResourcesProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.permissions.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CPX"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Permissions\\\\V1Beta1"
           }
         ]
       }
@@ -6759,6 +6949,36 @@
             ]
           },
           {
+            "name": "TouchFileRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "ref",
+                "type": "Reference"
+              }
+            ]
+          },
+          {
+            "name": "TouchFileResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
             "name": "DeleteRequest",
             "fields": [
               {
@@ -7599,6 +7819,146 @@
             ]
           },
           {
+            "name": "SetLockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "ref",
+                "type": "Reference"
+              },
+              {
+                "id": 3,
+                "name": "lock",
+                "type": "Lock"
+              }
+            ]
+          },
+          {
+            "name": "SetLockResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "GetLockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "ref",
+                "type": "Reference"
+              }
+            ]
+          },
+          {
+            "name": "GetLockResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 3,
+                "name": "lock",
+                "type": "Lock"
+              }
+            ]
+          },
+          {
+            "name": "RefreshLockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "ref",
+                "type": "Reference"
+              },
+              {
+                "id": 3,
+                "name": "lock",
+                "type": "Lock"
+              }
+            ]
+          },
+          {
+            "name": "RefreshLockResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
+            "name": "UnlockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "ref",
+                "type": "Reference"
+              },
+              {
+                "id": 3,
+                "name": "lock",
+                "type": "Lock"
+              }
+            ]
+          },
+          {
+            "name": "UnlockResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 2,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              }
+            ]
+          },
+          {
             "name": "CreateHomeRequest",
             "fields": [
               {
@@ -7818,6 +8178,11 @@
                 "out_type": "CreateContainerResponse"
               },
               {
+                "name": "TouchFile",
+                "in_type": "TouchFileRequest",
+                "out_type": "TouchFileResponse"
+              },
+              {
                 "name": "Delete",
                 "in_type": "DeleteRequest",
                 "out_type": "DeleteResponse"
@@ -7935,6 +8300,26 @@
                 "out_type": "UnsetArbitraryMetadataResponse"
               },
               {
+                "name": "SetLock",
+                "in_type": "SetLockRequest",
+                "out_type": "SetLockResponse"
+              },
+              {
+                "name": "GetLock",
+                "in_type": "GetLockRequest",
+                "out_type": "GetLockResponse"
+              },
+              {
+                "name": "RefreshLock",
+                "in_type": "RefreshLockRequest",
+                "out_type": "RefreshLockResponse"
+              },
+              {
+                "name": "Unlock",
+                "in_type": "UnlockRequest",
+                "out_type": "UnlockResponse"
+              },
+              {
                 "name": "CreateHome",
                 "in_type": "CreateHomeRequest",
                 "out_type": "CreateHomeResponse"
@@ -8020,6 +8405,26 @@
       "protopath": "cs3:/:storage:/:provider:/:v1beta1:/:resources.proto",
       "def": {
         "enums": [
+          {
+            "name": "LockType",
+            "enum_fields": [
+              {
+                "name": "LOCK_TYPE_INVALID"
+              },
+              {
+                "name": "LOCK_TYPE_SHARED",
+                "integer": 1
+              },
+              {
+                "name": "LOCK_TYPE_WRITE",
+                "integer": 2
+              },
+              {
+                "name": "LOCK_TYPE_EXCL",
+                "integer": 3
+              }
+            ]
+          },
           {
             "name": "ResourceType",
             "enum_fields": [
@@ -8162,6 +8567,17 @@
                 "id": 14,
                 "name": "arbitrary_metadata",
                 "type": "ArbitraryMetadata"
+              },
+              {
+                "id": 15,
+                "name": "lock",
+                "type": "Lock"
+              },
+              {
+                "id": 16,
+                "name": "advisory_locks",
+                "type": "Lock",
+                "is_repeated": true
               }
             ]
           },
@@ -8185,6 +8601,41 @@
                   "name": "metadata",
                   "type": "string"
                 }
+              }
+            ]
+          },
+          {
+            "name": "Lock",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "lock_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "LockType"
+              },
+              {
+                "id": 4,
+                "name": "user",
+                "type": "cs3.identity.user.v1beta1.UserId"
+              },
+              {
+                "id": 5,
+                "name": "app_name",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "expiration",
+                "type": "cs3.types.v1beta1.Timestamp"
               }
             ]
           },


### PR DESCRIPTION
In reva, we support basic auth through various mechanisms. One could be the simple auth provider which connects to an LDAP backend, but at the same time, we have the application auth service which is used to create temporary passwords with restricted scope. Both the services need to be enabled simultaneously and should be considered for a request trying to authenticate via basic auth. This PR enables that.