### PR TITLE
add grant methods to the gateway

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -203,6 +203,24 @@ service GatewayAPI {
   rpc UpdateStorageSpace(cs3.storage.provider.v1beta1.UpdateStorageSpaceRequest) returns (cs3.storage.provider.v1beta1.UpdateStorageSpaceResponse);
   // Deletes a storage space.
   rpc DeleteStorageSpace(cs3.storage.provider.v1beta1.DeleteStorageSpaceRequest) returns (cs3.storage.provider.v1beta1.DeleteStorageSpaceResponse);
+  // Adds a new grant for the provided reference.
+  // MUST return CODE_NOT_FOUND if the reference does not exist
+  rpc AddGrant(cs3.storage.provider.v1beta1.AddGrantRequest) returns (cs3.storage.provider.v1beta1.AddGrantResponse);
+  // Denies access to the provided reference.
+  // MUST return CODE_NOT_FOUND if the reference does not exist
+  rpc DenyGrant(cs3.storage.provider.v1beta1.DenyGrantRequest) returns (cs3.storage.provider.v1beta1.DenyGrantResponse);
+  // Returns the list of grants for the provided reference.
+  // MUST return CODE_NOT_FOUND if the reference does not exists.
+  rpc ListGrants(cs3.storage.provider.v1beta1.ListGrantsRequest) returns (cs3.storage.provider.v1beta1.ListGrantsResponse);
+  // Removes a grant for the provided reference.
+  // This is recursive and atomic for directories. Does not follow references.
+  // MUST return CODE_NOT_FOUND if the reference does not exist.
+  // MUST return CODE_NOT_FOUND if grant does not exist.
+  rpc RemoveGrant(cs3.storage.provider.v1beta1.RemoveGrantRequest) returns (cs3.storage.provider.v1beta1.RemoveGrantResponse);
+  // Updates an ACL for the provided reference.
+  // MUST return CODE_NOT_FOUND if the reference does not exist.
+  // MUST return CODE_FAILED_PRECONDITION if the acl does not exist.
+  rpc UpdateGrant(cs3.storage.provider.v1beta1.UpdateGrantRequest) returns (cs3.storage.provider.v1beta1.UpdateGrantResponse);
   // *****************************************************************/
   // ************************ APP PROVIDER ********************/
   // *****************************************************************/

--- a/docs/index.html
+++ b/docs/index.html
@@ -2780,7 +2780,50 @@ The caller MUST have write permissions on the resource.</p></td>
                 <td>DeleteStorageSpace</td>
                 <td><a href="#cs3.storage.provider.v1beta1.DeleteStorageSpaceRequest">.cs3.storage.provider.v1beta1.DeleteStorageSpaceRequest</a></td>
                 <td><a href="#cs3.storage.provider.v1beta1.DeleteStorageSpaceResponse">.cs3.storage.provider.v1beta1.DeleteStorageSpaceResponse</a></td>
-                <td><p>Deletes a storage space.
+                <td><p>Deletes a storage space.</p></td>
+              </tr>
+            
+              <tr>
+                <td>AddGrant</td>
+                <td><a href="#cs3.storage.provider.v1beta1.AddGrantRequest">.cs3.storage.provider.v1beta1.AddGrantRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.AddGrantResponse">.cs3.storage.provider.v1beta1.AddGrantResponse</a></td>
+                <td><p>Adds a new grant for the provided reference.
+MUST return CODE_NOT_FOUND if the reference does not exist</p></td>
+              </tr>
+            
+              <tr>
+                <td>DenyGrant</td>
+                <td><a href="#cs3.storage.provider.v1beta1.DenyGrantRequest">.cs3.storage.provider.v1beta1.DenyGrantRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.DenyGrantResponse">.cs3.storage.provider.v1beta1.DenyGrantResponse</a></td>
+                <td><p>Denies access to the provided reference.
+MUST return CODE_NOT_FOUND if the reference does not exist</p></td>
+              </tr>
+            
+              <tr>
+                <td>ListGrants</td>
+                <td><a href="#cs3.storage.provider.v1beta1.ListGrantsRequest">.cs3.storage.provider.v1beta1.ListGrantsRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.ListGrantsResponse">.cs3.storage.provider.v1beta1.ListGrantsResponse</a></td>
+                <td><p>Returns the list of grants for the provided reference.
+MUST return CODE_NOT_FOUND if the reference does not exists.</p></td>
+              </tr>
+            
+              <tr>
+                <td>RemoveGrant</td>
+                <td><a href="#cs3.storage.provider.v1beta1.RemoveGrantRequest">.cs3.storage.provider.v1beta1.RemoveGrantRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.RemoveGrantResponse">.cs3.storage.provider.v1beta1.RemoveGrantResponse</a></td>
+                <td><p>Removes a grant for the provided reference.
+This is recursive and atomic for directories. Does not follow references.
+MUST return CODE_NOT_FOUND if the reference does not exist.
+MUST return CODE_NOT_FOUND if grant does not exist.</p></td>
+              </tr>
+            
+              <tr>
+                <td>UpdateGrant</td>
+                <td><a href="#cs3.storage.provider.v1beta1.UpdateGrantRequest">.cs3.storage.provider.v1beta1.UpdateGrantRequest</a></td>
+                <td><a href="#cs3.storage.provider.v1beta1.UpdateGrantResponse">.cs3.storage.provider.v1beta1.UpdateGrantResponse</a></td>
+                <td><p>Updates an ACL for the provided reference.
+MUST return CODE_NOT_FOUND if the reference does not exist.
+MUST return CODE_FAILED_PRECONDITION if the acl does not exist.
 
 *****************************************************************/
 ************************ APP PROVIDER ********************/


### PR DESCRIPTION
# Description

The methods to work with Grants are currently only available directly on the storageprovider.

This PR adds them to the Gateway too.

## Background

We are using a stat cache in the gateway which also caches the grants. Currently it it completely unaware when something regarding the grants changes because these methods are currently called directly on the storage providers bypassing the gateway.

## Implementation

I aim to implement this on `master` and `edge` branch because the change is relatively contained.