### PR TITLE
Add namespace config to user preferences calls

### DIFF
--- a/cs3/preferences/v1beta1/preferences_api.proto
+++ b/cs3/preferences/v1beta1/preferences_api.proto
@@ -28,6 +28,7 @@ option java_package = "com.cs3.preferences.v1beta1";
 option objc_class_prefix = "CPX";
 option php_namespace = "Cs3\\Preferences\\V1Beta1";
 
+import "cs3/preferences/v1beta1/resources.proto";
 import "cs3/rpc/v1beta1/status.proto";
 
 // Preferences API.
@@ -56,7 +57,7 @@ service PreferencesAPI {
 
 message SetKeyRequest {
   // REQUIRED.
-  string key = 1;
+  PreferenceKey key = 1;
   // REQUIRED.
   // The value associated with the key.
   string val = 2;
@@ -70,7 +71,7 @@ message SetKeyResponse {
 
 message GetKeyRequest {
   // REQUIRED.
-  string key = 1;
+  PreferenceKey key = 1;
 }
 
 message GetKeyResponse {

--- a/cs3/preferences/v1beta1/resources.proto
+++ b/cs3/preferences/v1beta1/resources.proto
@@ -1,0 +1,38 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+syntax = "proto3";
+
+package cs3.preferences.v1beta1;
+
+option csharp_namespace = "Cs3.Preferences.V1Beta1";
+option go_package = "preferencesv1beta1";
+option java_multiple_files = true;
+option java_outer_classname = "ResourcesProto";
+option java_package = "com.cs3.preferences.v1beta1";
+option objc_class_prefix = "CPX";
+option php_namespace = "Cs3\\Preferences\\V1Beta1";
+
+// Represents a key object consisting of a namespace and a string key.
+message PreferenceKey {
+  // REQUIRED.
+  // The namespace to which the key belongs.
+  string namespace = 1;
+  // REQUIRED.
+  string key = 2;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -318,6 +318,21 @@
         
           
           <li>
+            <a href="#cs3%2fpreferences%2fv1beta1%2fresources.proto">cs3/preferences/v1beta1/resources.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#cs3.preferences.v1beta1.PreferenceKey"><span class="badge">M</span>PreferenceKey</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
             <a href="#cs3%2frpc%2fv1beta1%2fcode.proto">cs3/rpc/v1beta1/code.proto</a>
             <ul>
               
@@ -3577,7 +3592,7 @@ The response status. </p></td>
               
                 <tr>
                   <td>key</td>
-                  <td><a href="#string">string</a></td>
+                  <td><a href="#cs3.preferences.v1beta1.PreferenceKey">PreferenceKey</a></td>
                   <td></td>
                   <td><p>REQUIRED. </p></td>
                 </tr>
@@ -3634,7 +3649,7 @@ The value associated with the key. </p></td>
               
                 <tr>
                   <td>key</td>
-                  <td><a href="#string">string</a></td>
+                  <td><a href="#cs3.preferences.v1beta1.PreferenceKey">PreferenceKey</a></td>
                   <td></td>
                   <td><p>REQUIRED. </p></td>
                 </tr>
@@ -3712,6 +3727,52 @@ requested key.</p></td>
         </table>
 
         
+    
+      
+      <div class="file-heading">
+        <h2 id="cs3/preferences/v1beta1/resources.proto">cs3/preferences/v1beta1/resources.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="cs3.preferences.v1beta1.PreferenceKey">PreferenceKey</h3>
+        <p>Represents a key object consisting of a namespace and a string key.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>namespace</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The namespace to which the key belongs. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>key</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
     
       
       <div class="file-heading">

--- a/proto.lock
+++ b/proto.lock
@@ -1960,6 +1960,11 @@
                 "id": 4,
                 "name": "app",
                 "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           }
@@ -4459,7 +4464,7 @@
               {
                 "id": 1,
                 "name": "key",
-                "type": "string"
+                "type": "PreferenceKey"
               },
               {
                 "id": 2,
@@ -4484,7 +4489,7 @@
               {
                 "id": 1,
                 "name": "key",
-                "type": "string"
+                "type": "PreferenceKey"
               }
             ]
           },
@@ -4524,6 +4529,9 @@
         "imports": [
           {
             "path": "cs3/rpc/v1beta1/status.proto"
+          },
+          {
+            "path": "cs3/preferences/v1beta1/resources.proto"
           }
         ],
         "package": {
@@ -4545,6 +4553,61 @@
           {
             "name": "java_outer_classname",
             "value": "PreferencesApiProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.preferences.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CPX"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Preferences\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "cs3:/:preferences:/:v1beta1:/:resources.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "PreferenceKey",
+            "fields": [
+              {
+                "id": 1,
+                "name": "namespace",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "key",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "cs3.preferences.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Preferences.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "preferencesv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ResourcesProto"
           },
           {
             "name": "java_package",
@@ -6865,6 +6928,11 @@
                 "id": 3,
                 "name": "grant",
                 "type": "Grant"
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -6900,6 +6968,11 @@
                 "id": 3,
                 "name": "grantee",
                 "type": "Grantee"
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -6990,6 +7063,11 @@
                 "id": 2,
                 "name": "ref",
                 "type": "Reference"
+              },
+              {
+                "id": 3,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7105,6 +7183,11 @@
                 "id": 4,
                 "name": "if_match",
                 "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7141,6 +7224,11 @@
                 "id": 2,
                 "name": "ref",
                 "type": "Reference"
+              },
+              {
+                "id": 3,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7438,6 +7526,11 @@
                 "id": 3,
                 "name": "destination",
                 "type": "Reference"
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7508,6 +7601,11 @@
                 "id": 3,
                 "name": "key",
                 "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7548,6 +7646,11 @@
                 "id": 4,
                 "name": "restore_ref",
                 "type": "Reference"
+              },
+              {
+                "id": 5,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7583,6 +7686,11 @@
                 "id": 3,
                 "name": "grant",
                 "type": "Grant"
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7659,6 +7767,11 @@
                 "id": 3,
                 "name": "grant",
                 "type": "Grant"
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7764,6 +7877,11 @@
                 "id": 3,
                 "name": "arbitrary_metadata",
                 "type": "ArbitraryMetadata"
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },
@@ -7800,6 +7918,11 @@
                 "name": "arbitrary_metadata_keys",
                 "type": "string",
                 "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "lock_id",
+                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
The various user preferences can belong to various namespaces, for example, core, files, apps. This PR adds the required config for that.