### PR TITLE
Added parent_id reference to ResourceInfo

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -77,25 +77,32 @@ message ResourceInfo {
   // Is the accounting recursive?, could it be set to 0 for directories if recursive not supported? use another field?
   // TODO(moscicki): This needs to be defined also for other types (such as a symlink to a directory or file)
   uint64 size = 10;
-  // REQUIRED:
+  // REQUIRED.
   // Identifier of the owner of the resource.
   cs3.identity.user.v1beta1.UserId owner = 11;
-  // REQUIRED if ResourceType is either RESOURCE_TYPE_SYMLINK or RESOURCE_TYPE_REFERENCE
+  // OPTIONAL.
+  // if ResourceType is either RESOURCE_TYPE_SYMLINK or RESOURCE_TYPE_REFERENCE
+  // it MUST be specified.
   string target = 12;
   // OPTIONAL.
   // Additional metadata attached to the resource.
-  // If resource type is RESOURCE_TYPE_REFERENCE it MUST
+  // If ResourceType is RESOURCE_TYPE_REFERENCE it MUST
   // be specified.
   CanonicalMetadata canonical_metadata = 13;
   // OPTIONAL.
   // Arbitrary metadata attached to a resource.
   ArbitraryMetadata arbitrary_metadata = 14;
   // OPTIONAL.
-  // Exclusive or write lock on this resource that will limit modification of the resource to holders of the lock. Can be used by WOPI or other apps requiring exclusive locks.
+  // Exclusive or write lock on this resource that will limit modification of the resource to holders of the lock.
+  // Can be used by WOPI or other apps requiring write or exclusive locks.
   Lock lock = 15;
   // OPTIONAL.
   // Advisory locks on this resource. Can be used for shared locks or other forms of collaborative locks.
   repeated Lock advisory_locks = 16;
+  // OPTIONAL.
+  // Reference to the container of this resource. If path is relative it MUST be specified:
+  // in a context where access to the parent metadata is denied (e.g. single-file share), it MUST be set to 0.
+  ResourceId parent_id = 17;
 }
 
 // CanonicalMetadata contains extra metadata

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -100,8 +100,8 @@ message ResourceInfo {
   // Advisory locks on this resource. Can be used for shared locks or other forms of collaborative locks.
   repeated Lock advisory_locks = 16;
   // OPTIONAL.
-  // Reference to the container of this resource. If path is relative it MUST be specified:
-  // in a context where access to the parent metadata is denied (e.g. single-file share), it MUST be set to 0.
+  // Reference to the container of this resource. If path is relative it MUST be specified, regardless the
+  // access restrictions to the resource: a subsequent Stat() on it MAY return access denied if appropriate.
   ResourceId parent_id = 17;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -17363,7 +17363,7 @@ TODO(moscicki): This needs to be defined also for other types (such as a symlink
                   <td>owner</td>
                   <td><a href="#cs3.identity.user.v1beta1.UserId">cs3.identity.user.v1beta1.UserId</a></td>
                   <td></td>
-                  <td><p>REQUIRED:
+                  <td><p>REQUIRED.
 Identifier of the owner of the resource. </p></td>
                 </tr>
               
@@ -17371,7 +17371,9 @@ Identifier of the owner of the resource. </p></td>
                   <td>target</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>REQUIRED if ResourceType is either RESOURCE_TYPE_SYMLINK or RESOURCE_TYPE_REFERENCE </p></td>
+                  <td><p>OPTIONAL.
+if ResourceType is either RESOURCE_TYPE_SYMLINK or RESOURCE_TYPE_REFERENCE
+it MUST be specified. </p></td>
                 </tr>
               
                 <tr>
@@ -17380,7 +17382,7 @@ Identifier of the owner of the resource. </p></td>
                   <td></td>
                   <td><p>OPTIONAL.
 Additional metadata attached to the resource.
-If resource type is RESOURCE_TYPE_REFERENCE it MUST
+If ResourceType is RESOURCE_TYPE_REFERENCE it MUST
 be specified. </p></td>
                 </tr>
               
@@ -17397,7 +17399,8 @@ Arbitrary metadata attached to a resource. </p></td>
                   <td><a href="#cs3.storage.provider.v1beta1.Lock">Lock</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-Exclusive or write lock on this resource that will limit modification of the resource to holders of the lock. Can be used by WOPI or other apps requiring exclusive locks. </p></td>
+Exclusive or write lock on this resource that will limit modification of the resource to holders of the lock.
+Can be used by WOPI or other apps requiring write or exclusive locks. </p></td>
                 </tr>
               
                 <tr>
@@ -17406,6 +17409,15 @@ Exclusive or write lock on this resource that will limit modification of the res
                   <td>repeated</td>
                   <td><p>OPTIONAL.
 Advisory locks on this resource. Can be used for shared locks or other forms of collaborative locks. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>parent_id</td>
+                  <td><a href="#cs3.storage.provider.v1beta1.ResourceId">ResourceId</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+Reference to the container of this resource. If path is relative it MUST be specified:
+in a context where access to the parent metadata is denied (e.g. single-file share), it MUST be set to 0. </p></td>
                 </tr>
               
             </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17416,8 +17416,8 @@ Advisory locks on this resource. Can be used for shared locks or other forms of 
                   <td><a href="#cs3.storage.provider.v1beta1.ResourceId">ResourceId</a></td>
                   <td></td>
                   <td><p>OPTIONAL.
-Reference to the container of this resource. If path is relative it MUST be specified:
-in a context where access to the parent metadata is denied (e.g. single-file share), it MUST be set to 0. </p></td>
+Reference to the container of this resource. If path is relative it MUST be specified, regardless the
+access restrictions to the resource: a subsequent Stat() on it MAY return access denied if appropriate. </p></td>
                 </tr>
               
             </tbody>


### PR DESCRIPTION
As discussed in https://github.com/cs3org/reva/issues/1804#issuecomment-1076471437 this PR introduces a `parent_id` property in `ResourceInfo`.

The property is added as `OPTIONAL`, both to not introduce a breaking change and to keep compatibility with the case of absolute paths, where it is actually not needed.

@butonic and @wkloucek, do you agree on the spec? including the fact that for single-file shares it `MUST` be set to `0`?
