### PR TITLE
Add quicklink field to link resource

### DIFF
--- a/cs3/sharing/link/v1beta1/resources.proto
+++ b/cs3/sharing/link/v1beta1/resources.proto
@@ -103,6 +103,10 @@ message PublicShare {
   // GetPublicSharebyToken requests can be
   // authenticated.
   ShareSignature signature = 12;
+  // OPTIONAL
+  // A bool value indicating if the link is the quicklink
+  // the server will enforce a maximum of 1 quicklink per resource
+  bool quicklink = 13;
 }
 
 // The permissions for a share.


### PR DESCRIPTION
`quicklink` is a simple bool value that indicates a unique link. The server will enforce that there is at max 1 quicklink per resource. This way the client can be sure there are not more than 1 quicklink and can adjust its UI.