### PR TITLE
Add creator to grant

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -311,6 +311,9 @@ message Grant {
   // REQUIRED.
   // The permissions for the grant.
   ResourcePermissions permissions = 2;
+  // OPTIONAL
+  // The Creator of the grant
+  cs3.identity.user.v1beta1.UserId creator = 3;
 }
 
 // A grantee is the receiver of a grant.

--- a/docs/index.html
+++ b/docs/index.html
@@ -16972,6 +16972,13 @@ The grantee of the grant. </p></td>
 The permissions for the grant. </p></td>
                 </tr>
               
+                <tr>
+                  <td>creator</td>
+                  <td><a href="#cs3.identity.user.v1beta1.UserId">cs3.identity.user.v1beta1.UserId</a></td>
+                  <td></td>
+                  <td><p>The Creator of the grant </p></td>
+                </tr>
+              
             </tbody>
           </table>
 


### PR DESCRIPTION
The `Creator` is needed for grants, because creator may have special permissions when editing the grant