### PR TITLE
add spaceID to resourceID

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -283,6 +283,11 @@ message ResourceId {
   // uniquely identity the resource in the internal
   // implementation of the service.
   string opaque_id = 2;
+  // OPTIONAL.
+  // The internal id used by service implementor to
+  // uniquely identify the storage space.
+  // Used by the storageprovider to locate the correct storage space.
+  string space_id = 3;
 }
 
 // The representation of permissions attached to a resource.

--- a/docs/index.html
+++ b/docs/index.html
@@ -17725,6 +17725,16 @@ uniquely identity the resource in the internal
 implementation of the service. </p></td>
                 </tr>
               
+                <tr>
+                  <td>space_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+The internal id used by service implementor to
+uniquely identify the storage space.
+Used by the storageprovider to locate the correct storage space. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 


### PR DESCRIPTION
# Description

To correctly address storage spaces in reva, we need another id property on the resourceID.

This change is not breaking and should be compatible for the `master` and the `edge` branches.

1) `master`branch.

We do not need to change anything


2) `edge` branch

Currently the `storageID` attribute is used for a concatenated `<storageproviderID>$<spaceID>`

With this change, we will be able to separate them and have a clean implementation back.

@labkode @glpatcern I will also update the cs3apis on the master branch to keep everything on the same version of the apis.