### PR TITLE
Add an expiration to FileUploadProtocol

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -422,6 +422,9 @@ message FileUploadProtocol {
   // REQUIRED.
   // Tells to the gateway if the client should be exposed directly to the upload_endpoint.
   bool expose = 5;
+  // OPTIONAL.
+  // The time at which the upload will expire.
+  cs3.types.v1beta1.Timestamp expiration = 6;
 }
 
 // A file download protocol object stores information about

--- a/docs/index.html
+++ b/docs/index.html
@@ -17265,6 +17265,14 @@ the file. </p></td>
 Tells to the gateway if the client should be exposed directly to the upload_endpoint. </p></td>
                 </tr>
               
+                <tr>
+                  <td>expiration</td>
+                  <td><a href="#cs3.types.v1beta1.Timestamp">cs3.types.v1beta1.Timestamp</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+The time at which the upload will expire. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 


### PR DESCRIPTION
This change adds an optional `expiration` field to `FileUploadProtocol` which can be used to indicate how long an upload to that resource will be possible.