### PR TITLE
Added PREVIEW as an additional ViewMode for apps

### DIFF
--- a/cs3/app/provider/v1beta1/provider_api.proto
+++ b/cs3/app/provider/v1beta1/provider_api.proto
@@ -73,8 +73,14 @@ message OpenInAppRequest {
     VIEW_MODE_VIEW_ONLY = 1;
     // The resource can be downloaded.
     VIEW_MODE_READ_ONLY = 2;
-    // The resource can be downloaded and updated.
+    // The resource can be downloaded and updated. The underlying application
+    // MUST be a fully capable editor to support this mode.
     VIEW_MODE_READ_WRITE = 3;
+    // The resource can be downloaded and updated, but must be shown in
+    // preview mode. If the underlying application does not support a preview mode,
+    // or if in a view-only mode users are not allowed to switch to edit mode,
+    // then this mode MUST fall back to READ_WRITE.
+    VIEW_MODE_PREVIEW = 4;
   }
   ViewMode view_mode = 3;
   // REQUIRED.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5611,7 +5611,17 @@ Usually the rendering happens by using HTML iframes or in separate browser tabs.
               <tr>
                 <td>VIEW_MODE_READ_WRITE</td>
                 <td>3</td>
-                <td><p>The resource can be downloaded and updated.</p></td>
+                <td><p>The resource can be downloaded and updated. The underlying application
+MUST be a fully capable editor to support this mode.</p></td>
+              </tr>
+            
+              <tr>
+                <td>VIEW_MODE_PREVIEW</td>
+                <td>4</td>
+                <td><p>The resource can be downloaded and updated, but must be shown in
+preview mode. If the underlying application does not support a preview mode,
+or if in a view-only mode users are not allowed to switch to edit mode,
+then this mode MUST fall back to READ_WRITE.</p></td>
               </tr>
             
           </tbody>


### PR DESCRIPTION
This mini PR adds a new option for the `OpenInApp` endpoint.

The use-case for it is to provide a non-editable preview of documents to users in certain cases (typically, single-file shares / public links), yet having the ability to switch to edit mode if underlying permissions allow editing.

The current AppProvider's WOPI driver would fully delegate this to the WOPI server. Only the web frontend would need to have some `preview` action implemented, cc @wkloucek @diocas.