### PR TITLE
add more share filters

### DIFF
--- a/cs3/sharing/collaboration/v1beta1/resources.proto
+++ b/cs3/sharing/collaboration/v1beta1/resources.proto
@@ -176,6 +176,8 @@ message Filter {
     TYPE_CREATOR = 4;
     TYPE_GRANTEE_TYPE = 5;
     TYPE_EXCLUDE_DENIALS = 6;
+    TYPE_SPACE_ID = 7;
+    TYPE_STATE = 8;
   }
   // REQUIRED.
   Type type = 2;
@@ -184,5 +186,7 @@ message Filter {
     cs3.identity.user.v1beta1.UserId owner = 4;
     cs3.identity.user.v1beta1.UserId creator = 5;
     storage.provider.v1beta1.GranteeType grantee_type = 6;
+    string space_id = 7;
+    ShareState state = 8;
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -10778,6 +10778,20 @@ MUST return CODE_NOT_FOUND if the received share reference does not exist.</p></
                   <td><p> </p></td>
                 </tr>
               
+                <tr>
+                  <td>space_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>state</td>
+                  <td><a href="#cs3.sharing.collaboration.v1beta1.ShareState">ShareState</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -11116,6 +11130,18 @@ make the share unique. </p></td>
               <tr>
                 <td>TYPE_EXCLUDE_DENIALS</td>
                 <td>6</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_SPACE_ID</td>
+                <td>7</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_STATE</td>
+                <td>8</td>
                 <td><p></p></td>
               </tr>
             


### PR DESCRIPTION
Added share filters to filter shares by space id and by state

The space id filter is already being used in the Reva edge branch [1] but we never properly introduced it to the API and the state filter is a new change [2].

[1] https://github.com/cs3org/reva/blob/edge/pkg/share/share.go#L122-L131
[2] https://github.com/owncloud/ocis/issues/3843