### PR TITLE
Add description to public share

### DIFF
--- a/cs3/sharing/link/v1beta1/link_api.proto
+++ b/cs3/sharing/link/v1beta1/link_api.proto
@@ -123,6 +123,7 @@ message UpdatePublicShareRequest {
       TYPE_PASSWORD = 2;
       TYPE_EXPIRATION = 3;
       TYPE_DISPLAYNAME = 4;
+      TYPE_DESCRIPTION = 5;
     }
     // REQUIRED.
     // Defines the field to update.
@@ -133,6 +134,9 @@ message UpdatePublicShareRequest {
     // OPTIONAL
     // Defines the public link display name.
     string display_name = 5;
+    // OPTIONAL
+    // Defines the public link description.
+    string description = 6;
   }
   Update update = 3;
 }

--- a/cs3/sharing/link/v1beta1/resources.proto
+++ b/cs3/sharing/link/v1beta1/resources.proto
@@ -107,6 +107,9 @@ message PublicShare {
   // A bool value indicating if the link is the quicklink
   // the server will enforce a maximum of 1 quicklink per resource
   bool quicklink = 13;
+  // OPTIONAL
+  // Description of the share.
+  string description = 14;
 }
 
 // The permissions for a share.


### PR DESCRIPTION
Added a description to public shares, so an user can describe the scope of the share.