### PR TITLE
add new user type space owner

### DIFF
--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -75,4 +75,6 @@ enum UserType {
   USER_TYPE_FEDERATED = 6;
   // A lightweight user account without access to various major functionalities.
   USER_TYPE_LIGHTWEIGHT = 7;
+  // A space owner te allow access for public link or content indexing.
+  USER_TYPE_SPACE_OWNER = 8;
 }

--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -75,6 +75,6 @@ enum UserType {
   USER_TYPE_FEDERATED = 6;
   // A lightweight user account without access to various major functionalities.
   USER_TYPE_LIGHTWEIGHT = 7;
-  // A space owner te allow access for public link or content indexing.
+  // A space owner to allow access for public link or content indexing.
   USER_TYPE_SPACE_OWNER = 8;
 }


### PR DESCRIPTION
When accessing public shares in a project space (which has no owner, only managers) we need to be able to pass a userid through the system which permission checks can work with.

Another use case is when trying to index a space on behalf of the space owner.

In both cases the user id MUST be set to the space id to reflect which space is supposed to be indexed.

Signed-off-by: Jörn Friedrich Dreyer <jfd@butonic.de>