### PR TITLE
Get initiator's info on AcceptInvite

### DIFF
--- a/cs3/ocm/invite/v1beta1/invite_api.proto
+++ b/cs3/ocm/invite/v1beta1/invite_api.proto
@@ -121,6 +121,15 @@ message AcceptInviteResponse {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The initiator's user id of the workflow.
+  cs3.identity.user.v1beta1.UserId user_id = 3;
+  // REQUIRED.
+  // The initiator's email of the workflow.
+  string email = 4;
+  // REQUIRED.
+  // The initiator's display name of the workflow.
+  string display_name = 5;
 }
 
 message GetAcceptedUserRequest {

--- a/cs3/ocm/invite/v1beta1/invite_api.proto
+++ b/cs3/ocm/invite/v1beta1/invite_api.proto
@@ -100,6 +100,15 @@ message ForwardInviteResponse {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
+    // REQUIRED.
+  // The initiator's user id of the workflow.
+  cs3.identity.user.v1beta1.UserId user_id = 3;
+  // REQUIRED.
+  // The initiator's email of the workflow.
+  string email = 4;
+  // REQUIRED.
+  // The initiator's display name of the workflow.
+  string display_name = 5;
 }
 
 message AcceptInviteRequest {

--- a/docs/index.html
+++ b/docs/index.html
@@ -8295,6 +8295,12 @@ The type of user. </p></td>
                 <td><p>A lightweight user account without access to various major functionalities.</p></td>
               </tr>
             
+              <tr>
+                <td>USER_TYPE_SPACE_OWNER</td>
+                <td>8</td>
+                <td><p>A space owner to allow access for public link or content indexing.</p></td>
+              </tr>
+            
           </tbody>
         </table>
       
@@ -8963,6 +8969,30 @@ The response status. </p></td>
                   <td></td>
                   <td><p>OPTIONAL.
 Opaque information. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>user_id</td>
+                  <td><a href="#cs3.identity.user.v1beta1.UserId">cs3.identity.user.v1beta1.UserId</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The initiator&#39;s user id of the workflow. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>email</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The initiator&#39;s email of the workflow. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>display_name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+The initiator&#39;s display name of the workflow. </p></td>
                 </tr>
               
             </tbody>


### PR DESCRIPTION
https://github.com/cs3org/OCM-API/pull/54 requires that when accepting an invitation token, also the initiator's info are exchanged back.
This PR adds this info in the AcceptInvite response.