### PR TITLE
Add description when generating an invitation token

### DIFF
--- a/cs3/ocm/invite/v1beta1/invite_api.proto
+++ b/cs3/ocm/invite/v1beta1/invite_api.proto
@@ -67,6 +67,9 @@ message GenerateInviteTokenRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
+  // OPTIONAL.
+  // The description of the token.
+  string description = 2;
 }
 
 message GenerateInviteTokenResponse {


### PR DESCRIPTION
An invitation token has an optional field `description` that currently is not possible to set.
This PR adds an optional `description` field when generating an invitation token.