### PR TITLE
Notifications

### DIFF
--- a/cs3/sharing/link/v1beta1/link_api.proto
+++ b/cs3/sharing/link/v1beta1/link_api.proto
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 CERN
+// Copyright 2018-2023 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,6 +96,13 @@ message CreatePublicShareRequest {
   // Indicates a share used for internal usage,
   // not exposed by a ListPublicShares.
   bool internal = 5;
+  // OPTIONAL
+  // Whether to notify the owner of a share when a file is uploaded to it.
+  bool notify_uploads = 6;
+  // OPTIONAL
+  // Comma-separated list of extra email addresses to notify when a file is
+  // uploaded to the share.
+  string notify_uploads_extra_recipients = 7;
 }
 
 message CreatePublicShareResponse {
@@ -131,6 +138,8 @@ message UpdatePublicShareRequest {
       TYPE_EXPIRATION = 3;
       TYPE_DISPLAYNAME = 4;
       TYPE_DESCRIPTION = 5;
+      TYPE_NOTIFYUPLOADS = 6;
+      TYPE_NOTIFYUPLOADSEXTRARECIPIENTS = 7;
     }
     // REQUIRED.
     // Defines the field to update.
@@ -144,6 +153,13 @@ message UpdatePublicShareRequest {
     // OPTIONAL
     // Defines the public link description.
     string description = 6;
+    // OPTIONAL
+    // Whether to notify the owner of a share when a file is uploaded to it.
+    bool notify_uploads = 7;
+    // OPTIONAL
+    // Comma-separated list of extra email addresses to notify when a file is
+    // uploaded to the share.
+    string notify_uploads_extra_recipients = 8;
   }
   Update update = 3;
 }

--- a/cs3/sharing/link/v1beta1/resources.proto
+++ b/cs3/sharing/link/v1beta1/resources.proto
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 CERN
+// Copyright 2018-2023 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,6 +110,13 @@ message PublicShare {
   // OPTIONAL
   // Description of the share.
   string description = 14;
+  // OPTIONAL
+  // Whether to notify the owner of a share when a file is uploaded to it.
+  bool notify_uploads = 15;
+  // OPTIONAL
+  // Comma-separated list of extra email addresses to notify when a file is
+  // uploaded to the share.
+  string notify_uploads_extra_recipients = 16;
 }
 
 // The permissions for a share.

--- a/docs/index.html
+++ b/docs/index.html
@@ -11442,6 +11442,23 @@ Indicates a share used for internal usage,
 not exposed by a ListPublicShares. </p></td>
                 </tr>
               
+                <tr>
+                  <td>notify_uploads</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL
+Whether to notify the owner of a share when a file is uploaded to it. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>notify_uploads_extra_recipients</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL
+Comma-separated list of extra email addresses to notify when a file is
+uploaded to the share. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -11999,6 +12016,23 @@ Defines the public link display name. </p></td>
 Defines the public link description. </p></td>
                 </tr>
               
+                <tr>
+                  <td>notify_uploads</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL
+Whether to notify the owner of a share when a file is uploaded to it. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>notify_uploads_extra_recipients</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL
+Comma-separated list of extra email addresses to notify when a file is
+uploaded to the share. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -12125,6 +12159,18 @@ The updated public share. </p></td>
               <tr>
                 <td>TYPE_DESCRIPTION</td>
                 <td>5</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_NOTIFYUPLOADS</td>
+                <td>6</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TYPE_NOTIFYUPLOADSEXTRARECIPIENTS</td>
+                <td>7</td>
                 <td><p></p></td>
               </tr>
             
@@ -12383,6 +12429,23 @@ the server will enforce a maximum of 1 quicklink per resource </p></td>
                   <td></td>
                   <td><p>OPTIONAL
 Description of the share. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>notify_uploads</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL
+Whether to notify the owner of a share when a file is uploaded to it. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>notify_uploads_extra_recipients</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL
+Comma-separated list of extra email addresses to notify when a file is
+uploaded to the share. </p></td>
                 </tr>
               
             </tbody>


### PR DESCRIPTION
This PR adds two fields to the public link share API, in the context of the [new notification service in the backend](https://github.com/cernbox/reva/pull/43).

`notify_uploads` stores wheter the uploads to a public link will be notified to the owner, and `notify_uploads_extra_recipients` contains a comma-separated list of extra email addresses to notify too.