### PR TITLE
the code locked has been added

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -216,6 +216,7 @@ service GatewayAPI {
 
   // Creates a new share.
   // MUST return CODE_NOT_FOUND if the resource reference does not exist.
+  // MUST return CODE_LOCKED if the resource reference already locked.
   // MUST return CODE_ALREADY_EXISTS if the share already exists for the 4-tuple consisting of
   // (owner, shared_resource, grantee).
   // New shares MUST be created in the state SHARE_STATE_PENDING.

--- a/cs3/rpc/v1beta1/code.proto
+++ b/cs3/rpc/v1beta1/code.proto
@@ -191,4 +191,11 @@ enum Code {
   //
   // HTTP Mapping: 507 Insufficient Storage
   CODE_INSUFFICIENT_STORAGE = 19;
+  //
+  // The ability to lock a resource is specific to some WebDAV servers.
+  // The HTTP 423 Locked error response code indicates that either
+  // the resources tentatively targeted by is locked, meaning it can't be accessed.
+  //
+  // HTTP Mapping: 423 Locked
+  CODE_LOCKED = 20;
 }

--- a/cs3/sharing/collaboration/v1beta1/collaboration_api.proto
+++ b/cs3/sharing/collaboration/v1beta1/collaboration_api.proto
@@ -55,6 +55,7 @@ import "google/protobuf/field_mask.proto";
 service CollaborationAPI {
   // Creates a new share.
   // MUST return CODE_NOT_FOUND if the resource reference does not exist.
+  // MUST return CODE_LOCKED if the resource reference already locked.
   // MUST return CODE_ALREADY_EXISTS if the share already exists for the 4-tuple consisting of
   // (owner, shared_resource, grantee).
   // New shares MUST be created in the state SHARE_STATE_PENDING.

--- a/docs/index.html
+++ b/docs/index.html
@@ -2863,6 +2863,7 @@ MUST return CODE_NOT_FOUND if the resource does not exist.
                 <td><a href="#cs3.sharing.collaboration.v1beta1.CreateShareResponse">.cs3.sharing.collaboration.v1beta1.CreateShareResponse</a></td>
                 <td><p>Creates a new share.
 MUST return CODE_NOT_FOUND if the resource reference does not exist.
+MUST return CODE_LOCKED if the resource reference already locked.
 MUST return CODE_ALREADY_EXISTS if the share already exists for the 4-tuple consisting of
 (owner, shared_resource, grantee).
 New shares MUST be created in the state SHARE_STATE_PENDING.</p></td>
@@ -4079,6 +4080,16 @@ space or because of the exceeding of a quota associated to a
 storage.
 
 HTTP Mapping: 507 Insufficient Storage</p></td>
+              </tr>
+            
+              <tr>
+                <td>CODE_LOCKED</td>
+                <td>20</td>
+                <td><p>The ability to lock a resource is specific to some WebDAV servers.
+The HTTP 423 Locked error response code indicates that either
+the resources tentatively targeted by is locked, meaning it can&#39;t be accessed.
+
+HTTP Mapping: 423 Locked</p></td>
               </tr>
             
           </tbody>
@@ -10836,6 +10847,7 @@ The updated share. </p></td>
                 <td><a href="#cs3.sharing.collaboration.v1beta1.CreateShareResponse">CreateShareResponse</a></td>
                 <td><p>Creates a new share.
 MUST return CODE_NOT_FOUND if the resource reference does not exist.
+MUST return CODE_LOCKED if the resource reference already locked.
 MUST return CODE_ALREADY_EXISTS if the share already exists for the 4-tuple consisting of
 (owner, shared_resource, grantee).
 New shares MUST be created in the state SHARE_STATE_PENDING.</p></td>
@@ -13696,10 +13708,13 @@ Name of the shared resource. </p></td>
                 </tr>
               
                 <tr>
-                  <td>resource_id</td>
-                  <td><a href="#cs3.storage.provider.v1beta1.ResourceId">cs3.storage.provider.v1beta1.ResourceId</a></td>
+                  <td>remote_share_id</td>
+                  <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>REQUIRED. </p></td>
+                  <td><p>REQUIRED.
+Identifier to identify the shared resource at the provider side.
+This is unique per provider such that if the same resource is shared twice, this will not be repeated.
+This correspond to the `providerId` in the OCM API specs. </p></td>
                 </tr>
               
                 <tr>


### PR DESCRIPTION
# Description

This adds: CODE_LOCKED to the rpc codes
The ability to lock a resource is specific to some WebDAV servers. 
The HTTP 423 Locked error response code indicates that either the resources tentatively targeted by is locked, meaning it can't be accessed. 
HTTP Mapping: 423 Locked