### PR TITLE
Added target to OpenInAppURL object

### DIFF
--- a/cs3/app/provider/v1beta1/resources.proto
+++ b/cs3/app/provider/v1beta1/resources.proto
@@ -69,8 +69,8 @@ enum ViewMode {
 // Defines the valid targets for an app URL.
 enum Target {
   TARGET_INVALID = 0;
-  // The app URL is to be opened on an iframe
+  // The app URL is to be opened within an iframe
   TARGET_IFRAME = 1;
-  // The app URL is to be opened by redirecting to a new page
+  // The app URL is to be opened on a new blank page
   TARGET_BLANK = 2;
 }

--- a/cs3/app/provider/v1beta1/resources.proto
+++ b/cs3/app/provider/v1beta1/resources.proto
@@ -44,6 +44,9 @@ message OpenInAppURL {
   // OPTIONAL.
   // The headers to be added to the request.
   map<string, string> headers = 4;
+  // REQUIRED.
+  // Whether the target for the app URL is an iframe or a new page.
+  Target target = 5;
 }
 
 // Defines the view modes.
@@ -61,4 +64,13 @@ enum ViewMode {
   // or if in a view-only mode users are not allowed to switch to edit mode,
   // then this mode MUST fall back to READ_WRITE.
   VIEW_MODE_PREVIEW = 4;
+}
+
+// Defines the valid targets for an app URL.
+enum Target {
+  TARGET_INVALID = 0;
+  // The app URL is to be opened on an iframe
+  TARGET_IFRAME = 1;
+  // The app URL is to be opened by redirecting to a new page
+  TARGET_BLANK = 2;
 }

--- a/cs3/app/registry/v1beta1/resources.proto
+++ b/cs3/app/registry/v1beta1/resources.proto
@@ -40,7 +40,7 @@ message ProviderInfo {
   repeated string mime_types = 2;
   // REQUIRED.
   // The address where the app provider can be reached.
-  // For example, tcp://localhost:1099.
+  // For example, localhost:1099.
   string address = 3;
   // REQUIRED.
   // The capability of the underlying app.
@@ -66,6 +66,10 @@ message ProviderInfo {
   // OPTIONAL.
   // Whether the app can be opened only on desktop
   bool desktop_only = 8;
+  // OPTIONAL.
+  // The action to be displayed to the user on the context menu.
+  // By default this is "Open with".
+  string action = 9;
 }
 
 // Represents a mime type and its corresponding file extension.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5881,13 +5881,13 @@ Whether the target for the app URL is an iframe or a new page. </p></td>
               <tr>
                 <td>TARGET_IFRAME</td>
                 <td>1</td>
-                <td><p>The app URL is to be opened on an iframe</p></td>
+                <td><p>The app URL is to be opened within an iframe</p></td>
               </tr>
             
               <tr>
                 <td>TARGET_BLANK</td>
                 <td>2</td>
-                <td><p>The app URL is to be opened by redirecting to a new page</p></td>
+                <td><p>The app URL is to be opened on a new blank page</p></td>
               </tr>
             
           </tbody>
@@ -6562,7 +6562,7 @@ The mimetypes handled by this provider. </p></td>
                   <td></td>
                   <td><p>REQUIRED.
 The address where the app provider can be reached.
-For example, tcp://localhost:1099. </p></td>
+For example, localhost:1099. </p></td>
                 </tr>
               
                 <tr>
@@ -6604,6 +6604,15 @@ A URI to a static asset which represents the app icon. </p></td>
                   <td></td>
                   <td><p>OPTIONAL.
 Whether the app can be opened only on desktop </p></td>
+                </tr>
+              
+                <tr>
+                  <td>action</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>OPTIONAL.
+The action to be displayed to the user on the context menu.
+By default this is &#34;Open with&#34;. </p></td>
                 </tr>
               
             </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -594,6 +594,10 @@
               
               
                 <li>
+                  <a href="#cs3.app.provider.v1beta1.Target"><span class="badge">E</span>Target</a>
+                </li>
+              
+                <li>
                   <a href="#cs3.app.provider.v1beta1.ViewMode"><span class="badge">E</span>ViewMode</a>
                 </li>
               
@@ -5781,6 +5785,14 @@ These are sent only if the method is &#39;POST&#39;. </p></td>
 The headers to be added to the request. </p></td>
                 </tr>
               
+                <tr>
+                  <td>target</td>
+                  <td><a href="#cs3.app.provider.v1beta1.Target">Target</a></td>
+                  <td></td>
+                  <td><p>REQUIRED.
+Whether the target for the app URL is an iframe or a new page. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -5851,6 +5863,35 @@ The headers to be added to the request. </p></td>
         
       
 
+      
+        <h3 id="cs3.app.provider.v1beta1.Target">Target</h3>
+        <p>Defines the valid targets for an app URL.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>TARGET_INVALID</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>TARGET_IFRAME</td>
+                <td>1</td>
+                <td><p>The app URL is to be opened on an iframe</p></td>
+              </tr>
+            
+              <tr>
+                <td>TARGET_BLANK</td>
+                <td>2</td>
+                <td><p>The app URL is to be opened by redirecting to a new page</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
       
         <h3 id="cs3.app.provider.v1beta1.ViewMode">ViewMode</h3>
         <p>Defines the view modes.</p>


### PR DESCRIPTION
Also added `action` to AppProviderInfo.

The exercise here is to demonstrate a different kind of integration, where the app lives on an external cloud and uses its own login and storage. Therefore it can't be embedded in an iframe and the integration is more loose, with the user driving the `Export to` and `Import from` actions as opposed to a simple `Open with`.