### PR TITLE
Decouple spaces API from storage

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -46,6 +46,7 @@ import "cs3/sharing/collaboration/v1beta1/collaboration_api.proto";
 import "cs3/sharing/link/v1beta1/link_api.proto";
 import "cs3/sharing/ocm/v1beta1/ocm_api.proto";
 import "cs3/storage/provider/v1beta1/provider_api.proto";
+import "cs3/storage/provider/v1beta1/spaces_api.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/tx/v1beta1/tx_api.proto";
 import "cs3/types/v1beta1/types.proto";

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -28,7 +28,6 @@ option java_package = "com.cs3.storage.provider.v1beta1";
 option objc_class_prefix = "CSP";
 option php_namespace = "Cs3\\Storage\\Provider\\V1Beta1";
 
-import "cs3/identity/user/v1beta1/resources.proto";
 import "cs3/rpc/v1beta1/status.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
@@ -177,14 +176,6 @@ service ProviderAPI {
   rpc CreateHome(CreateHomeRequest) returns (CreateHomeResponse);
   // Gets the home path for the user.
   rpc GetHome(GetHomeRequest) returns (GetHomeResponse);
-  // Creates a storage space.
-  rpc CreateStorageSpace(CreateStorageSpaceRequest) returns (CreateStorageSpaceResponse);
-  // Lists storage spaces.
-  rpc ListStorageSpaces(ListStorageSpacesRequest) returns (ListStorageSpacesResponse);
-  // Updates a storage space.
-  rpc UpdateStorageSpace(UpdateStorageSpaceRequest) returns (UpdateStorageSpaceResponse);
-  // Deletes a storage space.
-  rpc DeleteStorageSpace(DeleteStorageSpaceRequest) returns (DeleteStorageSpaceResponse);
 }
 
 message GetHomeRequest {
@@ -1063,128 +1054,4 @@ message CreateHomeResponse {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 2;
-}
-
-message CreateStorageSpaceRequest {
-  // OPTIONAL.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  cs3.identity.user.v1beta1.User owner = 2;
-  // OPTIONAL.
-  // Could be 'home', 'share', 'project', 'space'...
-  string type = 3;
-  // OPTIONAL.
-  // User readable name of the storage space.
-  string name = 4;
-  // OPTIONAL.
-  Quota quota = 5;
-}
-
-message CreateStorageSpaceResponse {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  // The response status.
-  cs3.rpc.v1beta1.Status status = 2;
-  // REQUIRED.
-  // The created storage space.
-  StorageSpace storage_space = 3;
-}
-
-message ListStorageSpacesRequest {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // Represents a filter to apply to the request.
-  message Filter {
-    // The filter to apply.
-    enum Type {
-      TYPE_INVALID = 0;
-      TYPE_NO = 1;
-      TYPE_ID = 2;
-      TYPE_OWNER = 3;
-      TYPE_SPACE_TYPE = 4;
-      TYPE_PATH = 5;
-      TYPE_USER = 6;
-    }
-    // REQUIRED.
-    Type type = 1;
-    oneof term {
-      StorageSpaceId id = 2;
-      cs3.identity.user.v1beta1.UserId owner = 3;
-      string space_type = 4;
-      string path = 5;
-      cs3.identity.user.v1beta1.UserId user = 6;
-    }
-  }
-  // OPTIONAL.
-  // The list of filters to apply if any.
-  repeated Filter filters = 2;
-  // OPTIONAL.
-  // The field mask applies to the resource. For the `FieldMask` definition,
-  // see https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
-  google.protobuf.FieldMask field_mask = 3;
-  // OPTIONAL.
-  // Clients use this field to specify the maximum number of results to be returned by the server.
-  // The server may further constrain the maximum number of results returned in a single page.
-  // If the page_size is 0, the server will decide the number of results to be returned.
-  // see https://cloud.google.com/apis/design/design_patterns#list_pagination
-  int32 page_size = 4;
-  // OPTIONAL.
-  // The client uses this field to request a specific page of the list results.
-  string page_token = 5;
-}
-
-message ListStorageSpacesResponse {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  // The response status.
-  cs3.rpc.v1beta1.Status status = 2;
-  // REQUIRED.
-  repeated StorageSpace storage_spaces = 3;
-  // OPTIONAL.
-  // This field represents the pagination token to retrieve the next page of results.
-  // If the value is "", it means no further results for the request.
-  // see https://cloud.google.com/apis/design/design_patterns#list_pagination
-  string next_page_token = 4;
-}
-
-message UpdateStorageSpaceRequest {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  StorageSpace storage_space = 2;
-}
-
-message UpdateStorageSpaceResponse {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  // The response status.
-  cs3.rpc.v1beta1.Status status = 2;
-  // REQUIRED.
-  // The updated storage space.
-  StorageSpace storage_space = 3;
-}
-
-message DeleteStorageSpaceRequest {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  StorageSpaceId id = 2;
-}
-
-message DeleteStorageSpaceResponse {
-  // OPTIONAL.
-  // Opaque information.
-  cs3.types.v1beta1.Opaque opaque = 1;
-  // REQUIRED.
-  // The response status.
-  cs3.rpc.v1beta1.Status status = 2;
 }

--- a/cs3/storage/provider/v1beta1/spaces_api.proto
+++ b/cs3/storage/provider/v1beta1/spaces_api.proto
@@ -1,0 +1,187 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+syntax = "proto3";
+
+package cs3.storage.provider.v1beta1;
+
+option csharp_namespace = "Cs3.Storage.Provider.V1Beta1";
+option go_package = "providerv1beta1";
+option java_multiple_files = true;
+option java_outer_classname = "ProviderApiProto";
+option java_package = "com.cs3.storage.provider.v1beta1";
+option objc_class_prefix = "CSP";
+option php_namespace = "Cs3\\Storage\\Provider\\V1Beta1";
+
+import "cs3/identity/user/v1beta1/resources.proto";
+import "cs3/rpc/v1beta1/status.proto";
+import "cs3/storage/provider/v1beta1/resources.proto";
+import "cs3/types/v1beta1/types.proto";
+import "google/protobuf/field_mask.proto";
+
+// Spaces API
+//
+// The Spaces API is meant to manipulate spaces in the service.
+//
+// The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+// NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
+// "OPTIONAL" in this document are to be interpreted as described in
+// RFC 2119.
+//
+// The following are global requirements that apply to all methods:
+// Any method MUST return CODE_OK on a succesful operation.
+// Any method MAY return NOT_IMPLEMENTED.
+// Any method MAY return INTERNAL.
+// Any method MAY return UNKNOWN.
+// Any method MAY return UNAUTHENTICATED.
+
+service SpacesAPI {
+  // Creates a storage space.
+  rpc CreateStorageSpace(CreateStorageSpaceRequest) returns (CreateStorageSpaceResponse);
+  // Lists storage spaces.
+  rpc ListStorageSpaces(ListStorageSpacesRequest) returns (ListStorageSpacesResponse);
+  // Updates a storage space.
+  rpc UpdateStorageSpace(UpdateStorageSpaceRequest) returns (UpdateStorageSpaceResponse);
+  // Deletes a storage space.
+  rpc DeleteStorageSpace(DeleteStorageSpaceRequest) returns (DeleteStorageSpaceResponse);
+}
+
+
+message CreateStorageSpaceRequest {
+  // OPTIONAL.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  cs3.identity.user.v1beta1.User owner = 2;
+  // OPTIONAL.
+  // Could be 'home', 'share', 'project', 'space'...
+  string type = 3;
+  // OPTIONAL.
+  // User readable name of the storage space.
+  string name = 4;
+  // OPTIONAL.
+  Quota quota = 5;
+}
+
+message CreateStorageSpaceResponse {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 2;
+  // REQUIRED.
+  // The created storage space.
+  StorageSpace storage_space = 3;
+}
+
+message ListStorageSpacesRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // Represents a filter to apply to the request.
+  message Filter {
+    // The filter to apply.
+    enum Type {
+      TYPE_INVALID = 0;
+      TYPE_NO = 1;
+      TYPE_ID = 2;
+      TYPE_OWNER = 3;
+      TYPE_SPACE_TYPE = 4;
+      TYPE_PATH = 5;
+      TYPE_USER = 6;
+    }
+    // REQUIRED.
+    Type type = 1;
+    oneof term {
+      StorageSpaceId id = 2;
+      cs3.identity.user.v1beta1.UserId owner = 3;
+      string space_type = 4;
+      string path = 5;
+      cs3.identity.user.v1beta1.UserId user = 6;
+    }
+  }
+  // OPTIONAL.
+  // The list of filters to apply if any.
+  repeated Filter filters = 2;
+  // OPTIONAL.
+  // The field mask applies to the resource. For the `FieldMask` definition,
+  // see https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
+  google.protobuf.FieldMask field_mask = 3;
+  // OPTIONAL.
+  // Clients use this field to specify the maximum number of results to be returned by the server.
+  // The server may further constrain the maximum number of results returned in a single page.
+  // If the page_size is 0, the server will decide the number of results to be returned.
+  // see https://cloud.google.com/apis/design/design_patterns#list_pagination
+  int32 page_size = 4;
+  // OPTIONAL.
+  // The client uses this field to request a specific page of the list results.
+  string page_token = 5;
+}
+
+message ListStorageSpacesResponse {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 2;
+  // REQUIRED.
+  repeated StorageSpace storage_spaces = 3;
+  // OPTIONAL.
+  // This field represents the pagination token to retrieve the next page of results.
+  // If the value is "", it means no further results for the request.
+  // see https://cloud.google.com/apis/design/design_patterns#list_pagination
+  string next_page_token = 4;
+}
+
+message UpdateStorageSpaceRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  StorageSpace storage_space = 2;
+}
+
+message UpdateStorageSpaceResponse {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 2;
+  // REQUIRED.
+  // The updated storage space.
+  StorageSpace storage_space = 3;
+}
+
+message DeleteStorageSpaceRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  StorageSpaceId id = 2;
+}
+
+message DeleteStorageSpaceResponse {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 2;
+}

--- a/cs3/storage/provider/v1beta1/spaces_api.proto
+++ b/cs3/storage/provider/v1beta1/spaces_api.proto
@@ -23,7 +23,7 @@ package cs3.storage.provider.v1beta1;
 option csharp_namespace = "Cs3.Storage.Provider.V1Beta1";
 option go_package = "providerv1beta1";
 option java_multiple_files = true;
-option java_outer_classname = "ProviderApiProto";
+option java_outer_classname = "SpacesApiProto";
 option java_package = "com.cs3.storage.provider.v1beta1";
 option objc_class_prefix = "CSP";
 option php_namespace = "Cs3\\Storage\\Provider\\V1Beta1";
@@ -49,7 +49,6 @@ import "google/protobuf/field_mask.proto";
 // Any method MAY return INTERNAL.
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
-
 service SpacesAPI {
   // Creates a storage space.
   rpc CreateStorageSpace(CreateStorageSpaceRequest) returns (CreateStorageSpaceResponse);

--- a/proto.lock
+++ b/proto.lock
@@ -487,6 +487,22 @@
                 "integer": 4
               }
             ]
+          },
+          {
+            "name": "Target",
+            "enum_fields": [
+              {
+                "name": "TARGET_INVALID"
+              },
+              {
+                "name": "TARGET_IFRAME",
+                "integer": 1
+              },
+              {
+                "name": "TARGET_BLANK",
+                "integer": 2
+              }
+            ]
           }
         ],
         "messages": [
@@ -502,6 +518,11 @@
                 "id": 2,
                 "name": "method",
                 "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "target",
+                "type": "Target"
               }
             ],
             "maps": [
@@ -913,6 +934,11 @@
                 "id": 8,
                 "name": "desktop_only",
                 "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "action",
+                "type": "string"
               }
             ]
           },
@@ -2525,6 +2551,9 @@
           },
           {
             "path": "cs3/storage/provider/v1beta1/provider_api.proto"
+          },
+          {
+            "path": "cs3/storage/provider/v1beta1/spaces_api.proto"
           },
           {
             "path": "cs3/storage/provider/v1beta1/resources.proto"
@@ -5606,6 +5635,11 @@
                 "id": 3,
                 "name": "mount_point",
                 "type": "storage.provider.v1beta1.Reference"
+              },
+              {
+                "id": 4,
+                "name": "hidden",
+                "type": "bool"
               }
             ]
           },
@@ -7486,40 +7520,6 @@
     {
       "protopath": "cs3:/:storage:/:provider:/:v1beta1:/:provider_api.proto",
       "def": {
-        "enums": [
-          {
-            "name": "Filter.Type",
-            "enum_fields": [
-              {
-                "name": "TYPE_INVALID"
-              },
-              {
-                "name": "TYPE_NO",
-                "integer": 1
-              },
-              {
-                "name": "TYPE_ID",
-                "integer": 2
-              },
-              {
-                "name": "TYPE_OWNER",
-                "integer": 3
-              },
-              {
-                "name": "TYPE_SPACE_TYPE",
-                "integer": 4
-              },
-              {
-                "name": "TYPE_PATH",
-                "integer": 5
-              },
-              {
-                "name": "TYPE_USER",
-                "integer": 6
-              }
-            ]
-          }
-        ],
         "messages": [
           {
             "name": "GetHomeRequest",
@@ -8865,215 +8865,6 @@
                 "type": "cs3.types.v1beta1.Opaque"
               }
             ]
-          },
-          {
-            "name": "CreateStorageSpaceRequest",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "owner",
-                "type": "cs3.identity.user.v1beta1.User"
-              },
-              {
-                "id": 3,
-                "name": "type",
-                "type": "string"
-              },
-              {
-                "id": 4,
-                "name": "name",
-                "type": "string"
-              },
-              {
-                "id": 5,
-                "name": "quota",
-                "type": "Quota"
-              }
-            ]
-          },
-          {
-            "name": "CreateStorageSpaceResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "status",
-                "type": "cs3.rpc.v1beta1.Status"
-              },
-              {
-                "id": 3,
-                "name": "storage_space",
-                "type": "StorageSpace"
-              }
-            ]
-          },
-          {
-            "name": "ListStorageSpacesRequest",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "filters",
-                "type": "Filter",
-                "is_repeated": true
-              },
-              {
-                "id": 3,
-                "name": "field_mask",
-                "type": "google.protobuf.FieldMask"
-              },
-              {
-                "id": 4,
-                "name": "page_size",
-                "type": "int32"
-              },
-              {
-                "id": 5,
-                "name": "page_token",
-                "type": "string"
-              }
-            ],
-            "messages": [
-              {
-                "name": "Filter",
-                "fields": [
-                  {
-                    "id": 1,
-                    "name": "type",
-                    "type": "Type"
-                  },
-                  {
-                    "id": 2,
-                    "name": "id",
-                    "type": "StorageSpaceId"
-                  },
-                  {
-                    "id": 3,
-                    "name": "owner",
-                    "type": "cs3.identity.user.v1beta1.UserId"
-                  },
-                  {
-                    "id": 4,
-                    "name": "space_type",
-                    "type": "string"
-                  },
-                  {
-                    "id": 5,
-                    "name": "path",
-                    "type": "string"
-                  },
-                  {
-                    "id": 6,
-                    "name": "user",
-                    "type": "cs3.identity.user.v1beta1.UserId"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "ListStorageSpacesResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "status",
-                "type": "cs3.rpc.v1beta1.Status"
-              },
-              {
-                "id": 3,
-                "name": "storage_spaces",
-                "type": "StorageSpace",
-                "is_repeated": true
-              },
-              {
-                "id": 4,
-                "name": "next_page_token",
-                "type": "string"
-              }
-            ]
-          },
-          {
-            "name": "UpdateStorageSpaceRequest",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "storage_space",
-                "type": "StorageSpace"
-              }
-            ]
-          },
-          {
-            "name": "UpdateStorageSpaceResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "status",
-                "type": "cs3.rpc.v1beta1.Status"
-              },
-              {
-                "id": 3,
-                "name": "storage_space",
-                "type": "StorageSpace"
-              }
-            ]
-          },
-          {
-            "name": "DeleteStorageSpaceRequest",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "id",
-                "type": "StorageSpaceId"
-              }
-            ]
-          },
-          {
-            "name": "DeleteStorageSpaceResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "opaque",
-                "type": "cs3.types.v1beta1.Opaque"
-              },
-              {
-                "id": 2,
-                "name": "status",
-                "type": "cs3.rpc.v1beta1.Status"
-              }
-            ]
           }
         ],
         "services": [
@@ -9241,34 +9032,11 @@
                 "name": "GetHome",
                 "in_type": "GetHomeRequest",
                 "out_type": "GetHomeResponse"
-              },
-              {
-                "name": "CreateStorageSpace",
-                "in_type": "CreateStorageSpaceRequest",
-                "out_type": "CreateStorageSpaceResponse"
-              },
-              {
-                "name": "ListStorageSpaces",
-                "in_type": "ListStorageSpacesRequest",
-                "out_type": "ListStorageSpacesResponse"
-              },
-              {
-                "name": "UpdateStorageSpace",
-                "in_type": "UpdateStorageSpaceRequest",
-                "out_type": "UpdateStorageSpaceResponse"
-              },
-              {
-                "name": "DeleteStorageSpace",
-                "in_type": "DeleteStorageSpaceRequest",
-                "out_type": "DeleteStorageSpaceResponse"
               }
             ]
           }
         ],
         "imports": [
-          {
-            "path": "cs3/identity/user/v1beta1/resources.proto"
-          },
           {
             "path": "cs3/rpc/v1beta1/status.proto"
           },
@@ -10022,6 +9790,333 @@
           {
             "name": "java_outer_classname",
             "value": "ResourcesProto"
+          },
+          {
+            "name": "java_package",
+            "value": "com.cs3.storage.provider.v1beta1"
+          },
+          {
+            "name": "objc_class_prefix",
+            "value": "CSP"
+          },
+          {
+            "name": "php_namespace",
+            "value": "Cs3\\\\Storage\\\\Provider\\\\V1Beta1"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "cs3:/:storage:/:provider:/:v1beta1:/:spaces_api.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Filter.Type",
+            "enum_fields": [
+              {
+                "name": "TYPE_INVALID"
+              },
+              {
+                "name": "TYPE_NO",
+                "integer": 1
+              },
+              {
+                "name": "TYPE_ID",
+                "integer": 2
+              },
+              {
+                "name": "TYPE_OWNER",
+                "integer": 3
+              },
+              {
+                "name": "TYPE_SPACE_TYPE",
+                "integer": 4
+              },
+              {
+                "name": "TYPE_PATH",
+                "integer": 5
+              },
+              {
+                "name": "TYPE_USER",
+                "integer": 6
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "CreateStorageSpaceRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "owner",
+                "type": "cs3.identity.user.v1beta1.User"
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "quota",
+                "type": "Quota"
+              }
+            ]
+          },
+          {
+            "name": "CreateStorageSpaceResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 3,
+                "name": "storage_space",
+                "type": "StorageSpace"
+              }
+            ]
+          },
+          {
+            "name": "ListStorageSpacesRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "filters",
+                "type": "Filter",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "field_mask",
+                "type": "google.protobuf.FieldMask"
+              },
+              {
+                "id": 4,
+                "name": "page_size",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "page_token",
+                "type": "string"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Filter",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "type",
+                    "type": "Type"
+                  },
+                  {
+                    "id": 2,
+                    "name": "id",
+                    "type": "StorageSpaceId"
+                  },
+                  {
+                    "id": 3,
+                    "name": "owner",
+                    "type": "cs3.identity.user.v1beta1.UserId"
+                  },
+                  {
+                    "id": 4,
+                    "name": "space_type",
+                    "type": "string"
+                  },
+                  {
+                    "id": 5,
+                    "name": "path",
+                    "type": "string"
+                  },
+                  {
+                    "id": 6,
+                    "name": "user",
+                    "type": "cs3.identity.user.v1beta1.UserId"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ListStorageSpacesResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 3,
+                "name": "storage_spaces",
+                "type": "StorageSpace",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "next_page_token",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "UpdateStorageSpaceRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "storage_space",
+                "type": "StorageSpace"
+              }
+            ]
+          },
+          {
+            "name": "UpdateStorageSpaceResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              },
+              {
+                "id": 3,
+                "name": "storage_space",
+                "type": "StorageSpace"
+              }
+            ]
+          },
+          {
+            "name": "DeleteStorageSpaceRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "id",
+                "type": "StorageSpaceId"
+              }
+            ]
+          },
+          {
+            "name": "DeleteStorageSpaceResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "opaque",
+                "type": "cs3.types.v1beta1.Opaque"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "cs3.rpc.v1beta1.Status"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "SpacesAPI",
+            "rpcs": [
+              {
+                "name": "CreateStorageSpace",
+                "in_type": "CreateStorageSpaceRequest",
+                "out_type": "CreateStorageSpaceResponse"
+              },
+              {
+                "name": "ListStorageSpaces",
+                "in_type": "ListStorageSpacesRequest",
+                "out_type": "ListStorageSpacesResponse"
+              },
+              {
+                "name": "UpdateStorageSpace",
+                "in_type": "UpdateStorageSpaceRequest",
+                "out_type": "UpdateStorageSpaceResponse"
+              },
+              {
+                "name": "DeleteStorageSpace",
+                "in_type": "DeleteStorageSpaceRequest",
+                "out_type": "DeleteStorageSpaceResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "cs3/identity/user/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/rpc/v1beta1/status.proto"
+          },
+          {
+            "path": "cs3/storage/provider/v1beta1/resources.proto"
+          },
+          {
+            "path": "cs3/types/v1beta1/types.proto"
+          },
+          {
+            "path": "google/protobuf/field_mask.proto"
+          }
+        ],
+        "package": {
+          "name": "cs3.storage.provider.v1beta1"
+        },
+        "options": [
+          {
+            "name": "csharp_namespace",
+            "value": "Cs3.Storage.Provider.V1Beta1"
+          },
+          {
+            "name": "go_package",
+            "value": "providerv1beta1"
+          },
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ProviderApiProto"
           },
           {
             "name": "java_package",


### PR DESCRIPTION
The spaces API are currently coupled with the storage. This PR decouple them from the storage, allowing a more flexible implementation.