### PR TITLE
Clarified scope of lock_id in InitiateFileUploadRequest

### DIFF
--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -75,8 +75,9 @@ service ProviderAPI {
   // Initiates the download of a file using an
   // out-of-band data transfer mechanism.
   rpc InitiateFileDownload(InitiateFileDownloadRequest) returns (InitiateFileDownloadResponse);
-  // Initiates the upload of a file using an
-  // out-of-band data transfer mechanism.
+  // Initiates the upload of a file using an out-of-band
+  // data transfer mechanism. Locking MUST be handled by
+  // the data transfer protocol returned in response.
   rpc InitiateFileUpload(InitiateFileUploadRequest) returns (InitiateFileUploadResponse);
   // Returns the list of grants for the provided reference.
   // MUST return CODE_NOT_FOUND if the reference does not exists.
@@ -369,10 +370,6 @@ message InitiateFileUploadRequest {
     // return CODE_FAILED_PRECONDITION.
     cs3.types.v1beta1.Timestamp if_unmodified_since = 6;
   }
-  // OPTIONAL.
-  // A lock_id: should the reference exist and be locked, the stored
-  // lock_id MUST be equal to the given value.
-  string lock_id = 5;
 }
 
 message InitiateFileUploadResponse {

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -75,9 +75,11 @@ service ProviderAPI {
   // Initiates the download of a file using an
   // out-of-band data transfer mechanism.
   rpc InitiateFileDownload(InitiateFileDownloadRequest) returns (InitiateFileDownloadResponse);
-  // Initiates the upload of a file using an out-of-band
-  // data transfer mechanism. Locking MUST be handled by
-  // the data transfer protocol returned in response.
+  // Initiates the upload of a file using an out-of-band data
+  // transfer mechanism. SHOULD return CODE_FAILED_PRECONDITION
+  // if the reference is already locked with a mismatched lock.
+  // Additionally, the lock check MUST be enforced by the data
+  // transfer protocol returned in response.
   rpc InitiateFileUpload(InitiateFileUploadRequest) returns (InitiateFileUploadResponse);
   // Returns the list of grants for the provided reference.
   // MUST return CODE_NOT_FOUND if the reference does not exists.
@@ -370,6 +372,11 @@ message InitiateFileUploadRequest {
     // return CODE_FAILED_PRECONDITION.
     cs3.types.v1beta1.Timestamp if_unmodified_since = 6;
   }
+  // OPTIONAL.
+  // A lock_id: should the reference exist and be locked, the stored
+  // lock_id SHOULD be equal to the given value. Additionally, the
+  // check MUST be enforced by the out-of-band transfer protocol.
+  string lock_id = 5;
 }
 
 message InitiateFileUploadResponse {


### PR DESCRIPTION
The rationale of this PR is that an `InitiateFileUpload` request shall only provide an endpoint, for the client to perform the upload as a separate step. Therefore, any lock validation MUST be performed again at the actual upload time, when the `lock_id` is to be passed again, and as such there's no need to include it in the payload of InitiateFileUplod.

How is Reva/edge dealing with _atomically_ ensuring the lock is valid currently? @wkloucek and/or @micbar can you shed some light? My only guess is that you'd validate the lock again during the TUS upload. In that case, we may just shortcut.

For Reva/master, this is in the makings (at relatively low priority), that's why I realized only now about this.