### PR TITLE
Add calls for listing all types of shares and include storage resource info

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -235,6 +235,9 @@ service GatewayAPI {
   // both as owner and creator. If a filter is specified, only
   // shares satisfying the filter MUST be returned.
   rpc ListShares(cs3.sharing.collaboration.v1beta1.ListSharesRequest) returns (cs3.sharing.collaboration.v1beta1.ListSharesResponse);
+  // List all existing shares the authenticated principal has created,
+  // including their storage resource information.
+  rpc ListExistingShares(cs3.sharing.collaboration.v1beta1.ListSharesRequest) returns (ListExistingSharesResponse);
   // Updates a share.
   // MUST return CODE_NOT_FOUND if the share reference does not exist.
   rpc UpdateShare(cs3.sharing.collaboration.v1beta1.UpdateShareRequest) returns (cs3.sharing.collaboration.v1beta1.UpdateShareResponse);
@@ -281,6 +284,10 @@ service GatewayAPI {
   // both as owner and creator. If a filter is specified, only
   // shares satisfying the filter MUST be returned.
   rpc ListPublicShares(cs3.sharing.link.v1beta1.ListPublicSharesRequest) returns (cs3.sharing.link.v1beta1.ListPublicSharesResponse);
+  // List all existing shares the authenticated principal has created,
+  // both as owner and creator, including their storage resource information.
+  // If a filter is specified, only shares satisfying the filter MUST be returned.
+  rpc ListExistingPublicShares(cs3.sharing.link.v1beta1.ListPublicSharesRequest) returns (ListExistingPublicSharesResponse);
   // Updates a share.
   // MUST return CODE_NOT_FOUND if the share reference does not exist.
   rpc UpdatePublicShare(cs3.sharing.link.v1beta1.UpdatePublicShareRequest) returns (cs3.sharing.link.v1beta1.UpdatePublicShareResponse);
@@ -540,6 +547,23 @@ message ListAuthProvidersResponse {
   repeated string types = 3;
 }
 
+message ListExistingSharesResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The shares encapsulating both the share metadata and the storage metadata.
+  repeated ShareResourceInfo share_infos = 3;
+  // OPTIONAL.
+  // This field represents the pagination token to retrieve the next page of results.
+  // If the value is "", it means no further results for the request.
+  // see https://cloud.google.com/apis/design/design_patterns#list_pagination
+  string next_page_token = 4;
+}
+
 message ListExistingReceivedSharesResponse {
   // REQUIRED.
   // The response status.
@@ -549,7 +573,24 @@ message ListExistingReceivedSharesResponse {
   cs3.types.v1beta1.Opaque opaque = 2;
   // REQUIRED.
   // The shares encapsulating both the share metadata and the storage metadata.
-  repeated SharedResourceInfo shares = 3;
+  repeated ReceivedShareResourceInfo share_infos = 3;
+  // OPTIONAL.
+  // This field represents the pagination token to retrieve the next page of results.
+  // If the value is "", it means no further results for the request.
+  // see https://cloud.google.com/apis/design/design_patterns#list_pagination
+  string next_page_token = 4;
+}
+
+message ListExistingPublicSharesResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+  // REQUIRED.
+  // The shares encapsulating both the share metadata and the storage metadata.
+  repeated PublicShareResourceInfo share_infos = 3;
   // OPTIONAL.
   // This field represents the pagination token to retrieve the next page of results.
   // If the value is "", it means no further results for the request.

--- a/cs3/gateway/v1beta1/resources.proto
+++ b/cs3/gateway/v1beta1/resources.proto
@@ -22,6 +22,7 @@ package cs3.gateway.v1beta1;
 
 import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/sharing/collaboration/v1beta1/resources.proto";
+import "cs3/sharing/link/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 
 option csharp_namespace = "Cs3.Gateway.V1Beta1";
@@ -77,15 +78,43 @@ message FileDownloadProtocol {
   string token = 4;
 }
 
-// A shared resource includes the sharing information
-// and the storage-related information about a resource.
-message SharedResourceInfo {
+// ShareResourceInfo includes the sharing information
+// and the storage-related information about a share resource.
+message ShareResourceInfo {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
   // REQUIRED.
   // The underlying share as returned by the collaboration service.
-  cs3.sharing.collaboration.v1beta1.ReceivedShare share = 2;
+  cs3.sharing.collaboration.v1beta1.Share share = 2;
+  // REQUIRED.
+  // The corresponding resource information as returned by the storage provider.
+  cs3.storage.provider.v1beta1.ResourceInfo resource_info = 3;
+}
+
+// ReceivedShareResourceInfo includes the sharing information
+// and the storage-related information about a received share resource.
+message ReceivedShareResourceInfo {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The underlying share as returned by the collaboration service.
+  cs3.sharing.collaboration.v1beta1.ReceivedShare received_share = 2;
+  // REQUIRED.
+  // The corresponding resource information as returned by the storage provider.
+  cs3.storage.provider.v1beta1.ResourceInfo resource_info = 3;
+}
+
+// PublicShareResourceInfo includes the sharing information
+// and the storage-related information about a public share resource.
+message PublicShareResourceInfo {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The underlying share as returned by the collaboration service.
+  cs3.sharing.link.v1beta1.PublicShare public_share = 2;
   // REQUIRED.
   // The corresponding resource information as returned by the storage provider.
   cs3.storage.provider.v1beta1.ResourceInfo resource_info = 3;

--- a/cs3/sharing/link/v1beta1/resources.proto
+++ b/cs3/sharing/link/v1beta1/resources.proto
@@ -32,19 +32,6 @@ option java_package = "com.cs3.sharing.link.v1beta1";
 option objc_class_prefix = "CSL";
 option php_namespace = "Cs3\\Sharing\\Link\\V1Beta1";
 
-//
-//message PublicShare {
-//  string id = 1;
-//  string token = 2;
-//  string filename = 3;
-//  FileType file_type = 4;
-//  uint64 expiration = 5;
-//  bool password_protected = 6;
-//  Permission permission = 7;
-//  string display_name = 8;
-//  string owner = 9;
-//}
-//
 
 // Public share are relationships between a resource owner
 // (usually the authenticated user) who grants permissions to a recipient (grantee)


### PR DESCRIPTION
This is a breaking change as the recently added `ListExistingReceivedShares` has been redefined to make it more clear to use.

In addition, methods for `ListExistingShares` and `ListExistingPublicShares` have been added, following the same principle.