### PR TITLE
Add lock to TouchFile + minor comments

### DIFF
--- a/cs3/ocm/provider/v1beta1/resources.proto
+++ b/cs3/ocm/provider/v1beta1/resources.proto
@@ -81,19 +81,19 @@ message ProviderInfo {
   // REQUIRED.
   // The full name of the provider.
   string full_name = 2;
-  // REQUIRED.
+  // OPTIONAL.
   // A description of the provider.
   string description = 3;
-  // REQUIRED.
+  // OPTIONAL.
   // The organization to which the provider belongs.
   string organization = 4;
   // REQUIRED.
   // The domain of the sync'n'share provider.
   string domain = 5;
-  // REQUIRED.
+  // OPTIONAL.
   // The homepage of the provider.
   string homepage = 6;
-  // REQUIRED.
+  // OPTIONAL.
   // The email at which the provider can be reached.
   string email = 7;
   // REQUIRED.

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -272,6 +272,11 @@ message TouchFileRequest {
   // REQUIRED.
   // The reference to which the action should be performed.
   Reference ref = 2;
+  // OPTIONAL.
+  // A lock_id: should the reference be locked, the stored
+  // lock_id MUST be equal to the given value. However, implementations
+  // MAY allow touching an existing file even with a mismatching lock.
+  string lock_id = 3;
 }
 
 message TouchFileResponse {


### PR DESCRIPTION
`TouchFile` MAY also need the `lock_id` in some storage providers. See https://github.com/cs3org/wopiserver/pull/142#issuecomment-1898138468 for a case where it was missing.
