### PR TITLE
Updated build pipeline to not fail when there are no changes in the generated mocks

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -35,8 +35,7 @@ jobs:
           go install github.com/vektra/mockery/v2@v2.40.0 # Later versions are incompatible with Go 1.21
           mockery
           git add .
-          git commit -m 'Generated mock interfaces for https://github.com/cern-eos/grpc-proto/tree/${{ github.sha }}'
-          git push origin main
+          git commit -m 'Generated mock interfaces for https://github.com/cern-eos/grpc-proto/tree/${{ github.sha }}' && git push origin main || echo "Nothing to commit"
       - name: setup-buf
         uses: bufbuild/buf-setup-action@v1
       - name: push-buf


### PR DESCRIPTION
The current pipeline has a bit of code that generates mock files based on the defined interfaces, and then automatically commits them:
```
mockery
git add .
git commit -m 'Generated mock interfaces for https://github.com/cern-eos/grpc-proto/tree/${{ github.sha }}'
git push origin main
```

This makes the pipeline fail, because `git commit` will return a non-zero exit code when there is nothing to commit. This PR solves this issue.