### PR TITLE
added a product property product_name to the app provider info

### DIFF
--- a/cs3/app/registry/v1beta1/resources.proto
+++ b/cs3/app/registry/v1beta1/resources.proto
@@ -70,6 +70,11 @@ message ProviderInfo {
   // The action to be displayed to the user on the context menu.
   // By default this is "Open with".
   string action = 9;
+  // OPTIONAL.
+  // Specifies the kind of app provider.
+  // A product property that could be used to handle product-specific differences.
+  // For example: Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline
+  string product_name = 10;
 }
 
 // Represents a mime type and its corresponding file extension.


### PR DESCRIPTION
We added a product property `product_name` to the `app provider info`, that could be used to handle product-specific differences. For example Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline