### PR TITLE
RFE: add Share.description and ReceivedShare.alias

### DIFF
--- a/cs3/sharing/collaboration/v1beta1/resources.proto
+++ b/cs3/sharing/collaboration/v1beta1/resources.proto
@@ -67,9 +67,12 @@ message Share {
   // REQUIRED.
   // Last modification time of the share.
   cs3.types.v1beta1.Timestamp mtime = 8;
-  // Optional.
+  // OPTIONAL.
   // The expiration time of the share.
   cs3.types.v1beta1.Timestamp expiration = 9;
+  // OPTIONAL.
+  // A user-defined description for the share.
+  string description = 10;
 }
 
 // The permissions for a share.
@@ -92,9 +95,13 @@ message ReceivedShare {
   // REQUIRED.
   // The mount point of the share.
   storage.provider.v1beta1.Reference mount_point = 3;
-  // Optional.
-  // Hide share, default false
+  // OPTIONAL.
+  // Flag to hide the share, defaults to false.
   bool hidden = 4;
+  // OPTIONAL.
+  // An alternate identifier to allow a recipient to rename the share.
+  // If missing, use the original folder name.
+  string alias = 5;
 }
 
 // The state of the share.


### PR DESCRIPTION
This PR introduces two extra properties to shares:
* A `description` that the owner of a share can set when creating the share
* An `alias` each recipient of a share can set, to enable them renaming it in their "shared with me" view
