### PR TITLE
Adapted OCM payloads to OCM 1.2

### DIFF
--- a/cs3/ocm/core/v1beta1/ocm_core_api.proto
+++ b/cs3/ocm/core/v1beta1/ocm_core_api.proto
@@ -54,13 +54,13 @@ option php_namespace = "Cs3\\Ocm\\Core\\V1Beta1";
 // Any method MAY return UNAUTHENTICATED.
 service OcmCoreAPI {
   // Creates a new OCM share, in response to a call from remote to:
-  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1shares/post
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1shares/post
   rpc CreateOCMCoreShare(CreateOCMCoreShareRequest) returns (CreateOCMCoreShareResponse);
   // Updates an OCM share, in response to a notification from the remote system to:
-  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
   rpc UpdateOCMCoreShare(UpdateOCMCoreShareRequest) returns (UpdateOCMCoreShareResponse);
   // Deletes an OCM share, in response to a notification from the remote system to:
-  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
   rpc DeleteOCMCoreShare(DeleteOCMCoreShareRequest) returns (DeleteOCMCoreShareResponse);
 }
 
@@ -104,6 +104,9 @@ message CreateOCMCoreShareRequest {
   // See also cs3/sharing/ocm/v1beta1/resources.proto for how to map
   // this to the OCM share payload.
   repeated cs3.sharing.ocm.v1beta1.Protocol protocols = 11;
+  // OPTIONAL.
+  // A nonce to be exchanged for a (potentially short-lived) bearer token.
+  string code = 12;
 }
 
 message CreateOCMCoreShareResponse {

--- a/cs3/ocm/invite/v1beta1/invite_api.proto
+++ b/cs3/ocm/invite/v1beta1/invite_api.proto
@@ -59,7 +59,7 @@ service InviteAPI {
   rpc ListInviteTokens(ListInviteTokensRequest) returns (ListInviteTokensResponse);
   // Forwards a received invite to the remote sync'n'share system provider. The remote
   // system SHALL get an `invite-accepted` call as follows:
-  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1invite-accepted/post
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1invite-accepted/post
   // MUST return CODE_NOT_FOUND if the token does not exist.
   // MUST return CODE_INVALID_ARGUMENT if the token expired.
   // MUST return CODE_ALREADY_EXISTS if the user already accepted an invite.

--- a/cs3/sharing/ocm/v1beta1/resources.proto
+++ b/cs3/sharing/ocm/v1beta1/resources.proto
@@ -33,10 +33,9 @@ option java_package = "com.cs3.sharing.ocm.v1beta1";
 option objc_class_prefix = "CSO";
 option php_namespace = "Cs3\\Sharing\\Ocm\\V1Beta1";
 
-// Shares are relationships between a resource owner
-// (usually the authenticated user) who grants permissions to a recipient
-// (grantee) on a specified resource (resource_id). UserShares represents both
-// user and groups.
+// OCM Shares are shares created by a local owner (usually the authenticated user),
+// who grants permissions to a remote recipient (grantee) on a specified (local) resource (resource_id).
+// UserShares represents both user and groups.
 message Share {
   // REQUIRED.
   // Opaque unique identifier of the share.
@@ -78,9 +77,13 @@ message Share {
   // Recipient share type.
   cs3.sharing.ocm.v1beta1.ShareType share_type = 11;
   // REQUIRED.
+  // Access methods represent how remote users would access the local resource.
   repeated AccessMethod access_methods = 12;
   // OPTIONAL.
-  cs3.types.v1beta1.Opaque opaque = 13;
+  // A nonce to be exchanged for a (potentially short-lived) bearer token.
+  string code = 13;
+  // OPTIONAL.
+  cs3.types.v1beta1.Opaque opaque = 14;
 }
 
 // The permissions for a share.
@@ -89,7 +92,7 @@ message SharePermissions {
   bool reshare = 2;
 }
 
-// A received share is the share that a grantee will receive.
+// A received share represents a share offered by a remote user to a local grantee.
 message ReceivedShare {
   // REQUIRED.
   // Opaque unique identifier of the share.
@@ -146,6 +149,9 @@ message ReceivedShare {
   // REQUIRED.
   // Resource type.
   cs3.storage.provider.v1beta1.ResourceType resource_type = 14;
+  // OPTIONAL.
+  // A nonce to be exchanged for a (potentially short-lived) bearer token.
+  string code = 15;
 }
 
 // The state of the share.
@@ -251,18 +257,24 @@ message WebDAVProtocol {
   // Permissions of the shared resource.
   cs3.sharing.ocm.v1beta1.SharePermissions permissions = 2;
   // REQUIRED.
-  // WebDAV URI used to access the resource.
+  // Path-only URI used to access the resource.
   string uri = 3;
+  // OPTIONAL.
+  // The requirements for the share.
+  repeated string requirements = 4;
 }
 
 // Defines the options for the Webapp protocol.
 message WebappProtocol {
   // REQUIRED.
-  // Template URI to open the resource with a remote app.
-  string uri_template = 1;
+  // Path-only URI to open the resource with a remote app.
+  string uri = 1;
   // REQUIRED.
   // View mode for the remote app.
   cs3.app.provider.v1beta1.ViewMode view_mode = 2;
+  // OPTIONAL.
+  // Secret used to access the resource.
+  string shared_secret = 3;
 }
 
 // Defines the options for the Transfer protocol.
@@ -309,6 +321,9 @@ message WebDAVAccessMethod {
   // REQUIRED.
   // The permissions for the share.
   storage.provider.v1beta1.ResourcePermissions permissions = 1;
+  // OPTIONAL.
+  // The requirements for the share.
+  repeated string requirements = 2;
 }
 
 // Defines the options for the Webapp access method.


### PR DESCRIPTION
This PR includes the necessary changes in order to accommodate the new properties in OCM 1.2.

The only breaking change is with the `webapp` protocol payload, as `uri_template` has been renamed `uri`. But "to the best of our knowledge" only Reva master implements apps sharing and will be adapted. Other Reva implementations would remain compatible.