### PR TITLE
add hasTrashedItems property to drive object

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -473,6 +473,9 @@ message StorageSpace {
   // OPTIONAL.
   // Resource info for the storage space root.
   ResourceInfo root_info = 9;
+  // OPTIONAL.
+  // HasTrashedItems indicates if the storage space has trashed items.
+  bool has_trashed_items = 10;
 }
 
 // The id of a storage space.


### PR DESCRIPTION
This PR adds an aditional bool flag to the drive item called `hasTrashItems` this is used to show whether there are items in the drives trashbin or not.  

With that little change, everybody will be able to implement a cost-efficient way to query whether a storage provider has trashed items, without having to read the whole trashbin. (our current implementation can be reviewed here for decomposedfs and posixfs: https://github.com/opencloud-eu/reva/pull/268/files)