### PR TITLE
Add a tenant_id to UserIds

### DIFF
--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -42,6 +42,10 @@ message UserId {
   // REQUIRED.
   // The type of user.
   UserType type = 3;
+  // OPTIONAL.
+  // The tenant id of the user, if applicable.
+  // This is used to identify users in multi-tenant systems.
+  string tenant_id = 4;
 }
 
 // Represents a user of the system.


### PR DESCRIPTION
This pull request introduces an optional `tenant_id` field to `UserId`, which allows for identifying the tenant of the corresponding user.