### PR TITLE
Add thumbnail and readme IDs directly to space definition + add support for updating space quota and name

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -480,8 +480,11 @@ message StorageSpace {
   // Description of the space.
   string description = 11;
   // OPTIONAL.
-  // SpaceMetadata contains additional metadata about the space stored externally, such as subtitle, thumbnail, etc.
-  SpaceMetadata metadata = 12;
+  // An opaque ID of an optional thumbnail file of the space (usually the inode)
+  string thumbnail_id = 13;
+  // OPTIONAL.
+  // An opaque ID of an optional readme file of the space (usually the inode)
+  string readme_id = 14;
 }
 
 // The id of a storage space.
@@ -510,14 +513,3 @@ message Quota {
   uint64 remaining_files = 5;
 }
 
-
-message SpaceMetadata {
-  // Type of metadata entry
-  enum Type {
-    TYPE_README = 0;
-    TYPE_THUMBNAIL = 1;
-  }
-  Type type = 1;
-  // ID of the entry, usually the inode of the file that contains the actual metadata.
-  string id = 2;
-}

--- a/cs3/storage/provider/v1beta1/spaces_api.proto
+++ b/cs3/storage/provider/v1beta1/spaces_api.proto
@@ -163,6 +163,10 @@ message UpdateStorageSpaceRequest {
       string alias = 2;
       // Update IDs of "special" files, such as readme or thumbnail, directly stored in the space.
       SpaceMetadata metadata = 3;
+      // Update the space quota.
+      Quota quota = 4;
+      // Update the space name.
+      string name = 5;
     }
   }
   // REQUIRED.
@@ -196,4 +200,15 @@ message DeleteStorageSpaceResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 2;
+}
+
+message SpaceMetadata {
+  // Type of metadata entry
+  enum Type {
+    TYPE_README = 0;
+    TYPE_THUMBNAIL = 1;
+  }
+  Type type = 1;
+  // ID of the entry, usually the inode of the file that contains the actual metadata.
+  string id = 2;
 }


### PR DESCRIPTION
The space definition now contains fields for the inodes of special files, specifically of the readme and thumbnail of a space