### PR TITLE
Introduced the Incoming OCM API. Fixes #150.

### DIFF
--- a/cs3/ocm/incoming/v1beta1/ocm_incoming_api.proto
+++ b/cs3/ocm/incoming/v1beta1/ocm_incoming_api.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package cs3.ocm.core.v1beta1;
+package cs3.ocm.incoming.v1beta1;
 
 import "cs3/identity/user/v1beta1/resources.proto";
 import "cs3/rpc/v1beta1/status.proto";
@@ -26,21 +26,22 @@ import "cs3/sharing/ocm/v1beta1/resources.proto";
 import "cs3/storage/provider/v1beta1/resources.proto";
 import "cs3/types/v1beta1/types.proto";
 
-option csharp_namespace = "Cs3.Ocm.Core.V1Beta1";
-option go_package = "corev1beta1";
+option csharp_namespace = "Cs3.Ocm.Incoming.V1Beta1";
+option go_package = "incomingv1beta1";
 option java_multiple_files = true;
-option java_outer_classname = "OcmCoreApiProto";
-option java_package = "com.cs3.ocm.core.v1beta1";
-option objc_class_prefix = "COC";
-option php_namespace = "Cs3\\Ocm\\Core\\V1Beta1";
+option java_outer_classname = "OcmIncomingApiProto";
+option java_package = "com.cs3.ocm.incoming.v1beta1";
+option objc_class_prefix = "COI";
+option php_namespace = "Cs3\\Ocm\\Incoming\\V1Beta1";
 
-// OCM Core API (deprecated and to be removed, use cs3/ocm/incoming/v1beta1/incoming_api.proto instead)
+// OCM Incoming API
 //
-// This API is the mapping for the local system of the Open Cloud Mesh
-// (OCM) sharing protocol. Implementations are expected to expose the `/ocm`
-// endpoints according to the OCM API, and in response to those endpoints call the
-// following API. Support for multi-protocol shares is included, if the remote
-// sender supplies a multi-protocol share.
+// The OCM Incoming API is used to persist in the local system the incoming remote
+// shares that are sent via the Open Cloud Mesh (OCM) sharing protocol.
+// Implementations are expected to expose the `/ocm` endpoints according to the
+// OCM API, and in response to those endpoints call the following API.
+// Support for multi-protocol shares is included, if the remote sender supplies
+// a multi-protocol share.
 //
 // The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
 // NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
@@ -53,17 +54,19 @@ option php_namespace = "Cs3\\Ocm\\Core\\V1Beta1";
 // Any method MAY return INTERNAL.
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
-service OcmCoreAPI {
-  // Deprecated. Creates a new OCM share, in response to a call from the remote system
-  rpc CreateOCMCoreShare(CreateOCMCoreShareRequest) returns (CreateOCMCoreShareResponse);
-  // Deprecated. Updates an OCM share, in response to a notification from the remote system
-  rpc UpdateOCMCoreShare(UpdateOCMCoreShareRequest) returns (UpdateOCMCoreShareResponse);
-  // Deprecated. Deletes an OCM share, in response to a notification from the remote system
-  rpc DeleteOCMCoreShare(DeleteOCMCoreShareRequest) returns (DeleteOCMCoreShareResponse);
+service OcmIncomingAPI {
+  // Creates a new OCM share in response to a call from remote to `/ocm/shares`. See:
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1shares/post
+  rpc CreateIncomingOCMShare(CreateIncomingOCMShareRequest) returns (CreateIncomingOCMShareResponse);
+  // Updates an OCM share in response to a notification from remote to `/ocm/notifications`. See:
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
+  rpc UpdateIncomingOCMShare(UpdateIncomingOCMShareRequest) returns (UpdateIncomingOCMShareResponse);
+  // Deletes an OCM share in response to a notification from remote to `/ocm/notifications`. See:
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
+  rpc DeleteIncomingOCMShare(DeleteIncomingOCMShareRequest) returns (DeleteIncomingOCMShareResponse);
 }
 
-
-message CreateOCMCoreShareRequest {
+message CreateIncomingOCMShareRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
@@ -108,7 +111,7 @@ message CreateOCMCoreShareRequest {
   string code = 12;
 }
 
-message CreateOCMCoreShareResponse {
+message CreateIncomingOCMShareResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -122,7 +125,7 @@ message CreateOCMCoreShareResponse {
   cs3.types.v1beta1.Timestamp created = 4;
 }
 
-message UpdateOCMCoreShareRequest {
+message UpdateIncomingOCMShareRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
@@ -144,7 +147,7 @@ message UpdateOCMCoreShareRequest {
   repeated cs3.sharing.ocm.v1beta1.Protocol protocols = 7;
 }
 
-message UpdateOCMCoreShareResponse {
+message UpdateIncomingOCMShareResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -153,7 +156,7 @@ message UpdateOCMCoreShareResponse {
   cs3.types.v1beta1.Opaque opaque = 2;
 }
 
-message DeleteOCMCoreShareRequest {
+message DeleteIncomingOCMShareRequest {
   // REQUIRED.
   // Unique ID to identify the share at the consumer side.
   string id = 1;
@@ -162,7 +165,7 @@ message DeleteOCMCoreShareRequest {
   cs3.types.v1beta1.Opaque opaque = 2;
 }
 
-message DeleteOCMCoreShareResponse {
+message DeleteIncomingOCMShareResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;

--- a/cs3/sharing/collaboration/v1beta1/collaboration_api.proto
+++ b/cs3/sharing/collaboration/v1beta1/collaboration_api.proto
@@ -37,9 +37,10 @@ option php_namespace = "Cs3\\Sharing\\Collaboration\\V1Beta1";
 // User Share Provider API
 //
 // The User Share Provider API is meant to manipulate share
-// resources for a specific share type (user, group, ocm, ...)
-// from the perspective of the creator or the share and
-// from the perspective of the receiver of the share.
+// resources for a specific share type (user or group)
+// from the perspective of the creator of the share and
+// from the perspective of the recipient, both known to
+// the local system. See OCM for remote shares.
 //
 // The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
 // NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and

--- a/cs3/sharing/ocm/v1beta1/ocm_api.proto
+++ b/cs3/sharing/ocm/v1beta1/ocm_api.proto
@@ -36,13 +36,15 @@ option java_package = "com.cs3.sharing.ocm.v1beta1";
 option objc_class_prefix = "CSO";
 option php_namespace = "Cs3\\Sharing\\Ocm\\V1Beta1";
 
-// OCM Share Provider API
+// OCM API
 //
-// The OCM Share Provider API is meant to manipulate share
-// resources from the perspective of the creator or the share and
-// from the perspective of the receiver of the share.
+// The OCM API is a share API meant for local users to offer local
+// resources to remote recipients via the Open Cloud Mesh (OCM) protocol,
+// and to manipulate shares received from remote users.
+// Implementations are expected to call remote `/ocm` endpoints
+// in response to the payloads received via this API.
 //
-// The following APIs match the OCM v1.1 spec including multi-protocol shares.
+// The APIs match the OCM v1.2 spec including multi-protocol shares.
 //
 // The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
 // NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
@@ -56,19 +58,18 @@ option php_namespace = "Cs3\\Sharing\\Ocm\\V1Beta1";
 // Any method MAY return UNKNOWN.
 // Any method MAY return UNAUTHENTICATED.
 service OcmAPI {
-  // Creates a new ocm share.
+  // Creates a new OCM share.
   // MUST return CODE_NOT_FOUND if the resource reference does not exist.
-  // MUST return CODE_ALREADY_EXISTS if the share already exists for the 4-tuple consisting of
+  // MUST return CODE_ALREADY_EXISTS if the share already exists for the 3-tuple consisting of
   // (owner, shared_resource, grantee).
   // New shares MUST be created in the state SHARE_STATE_PENDING, and MUST be sent
-  // to the remote system using the OCM API at:
-  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1shares/post
+  // to the remote system using the `/ocm/shares` OCM API, see:
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1shares/post
   rpc CreateOCMShare(CreateOCMShareRequest) returns (CreateOCMShareResponse);
-  // Removes a share.
+  // Removes an OCM share.
   // MUST return CODE_NOT_FOUND if the share reference does not exist.
-  // This action SHALL be notified to the remote system
-  // using the OCM API at:
-  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
+  // This action MUST be notified to the remote system using the `/ocm/notifications` OCM API at:
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
   rpc RemoveOCMShare(RemoveOCMShareRequest) returns (RemoveOCMShareResponse);
   // Gets share information for a single share.
   // MUST return CODE_NOT_FOUND if the share reference does not exist.
@@ -76,17 +77,16 @@ service OcmAPI {
   // Gets share information for a single share by its unlisted token.
   // MUST return CODE_NOT_FOUND if the share does not exist.
   rpc GetOCMShareByToken(GetOCMShareByTokenRequest) returns (GetOCMShareByTokenResponse);
-  // List the shares the authenticated principal has created,
+  // List the shares the currently authenticated user has created,
   // both as owner and creator. If a filter is specified, only
   // shares satisfying the filter MUST be returned.
   rpc ListOCMShares(ListOCMSharesRequest) returns (ListOCMSharesResponse);
   // Updates a share.
   // MUST return CODE_NOT_FOUND if the share reference does not exist.
-  // This action SHALL be notified to the remote system
-  // using the OCM API at:
-  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
+  // This action MUST be notified to the remote system using the `/ocm/notifications` OCM API at:
+  // https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org#/paths/~1notifications/post
   rpc UpdateOCMShare(UpdateOCMShareRequest) returns (UpdateOCMShareResponse);
-  // List all shares the authenticated principal has received.
+  // List all shares the currently authenticated user has received.
   rpc ListReceivedOCMShares(ListReceivedOCMSharesRequest) returns (ListReceivedOCMSharesResponse);
   // Update the received share to change the share state or the display name.
   // MUST return CODE_NOT_FOUND if the share reference does not exist.


### PR DESCRIPTION
This is a breaking change as a new API is introduced, but it serves as a one-on-one replacement of the so-called (and mis-named) "Core OCM" API, which is now deprecated and will be removed in a later change.
