### PR TITLE
Add status to User

### DIFF
--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -95,6 +95,11 @@ message User {
   // OPTIONAL.
   // The group id of this user in the Unix world.
   int64 gid_number = 9;
+  // OPTIONAL.
+  // The status of this user in the tenant it belongs to.
+  // Useful for tenants implementing a users lifecycle,
+  // otherwise it defaults to ACTIVE.
+  UserStatus status = 10;
 }
 
 // The type of user.
@@ -118,3 +123,17 @@ enum UserType {
   // A space owner to allow access for public link or content indexing.
   USER_TYPE_SPACE_OWNER = 8;
 }
+
+// The status of a user.
+enum UserStatus {
+  // The user status is invalid.
+  USER_STATUS_INVALID = 0;
+  // The user is active and allowed to log in.
+  USER_STATUS_ACTIVE = 1;
+  // The user can log in but its validity is about to expire.
+  // The actual grace period the user is granted depends on its tenant's policy.
+  USER_STATUS_EXPIRING = 2;
+  // The user is valid but it has been blocked from login in its tenant.
+  USER_STATUS_BLOCKED = 3;
+}
+

--- a/cs3/identity/user/v1beta1/resources.proto
+++ b/cs3/identity/user/v1beta1/resources.proto
@@ -126,14 +126,12 @@ enum UserType {
 
 // The status of a user.
 enum UserStatus {
-  // The user status is invalid.
-  USER_STATUS_INVALID = 0;
   // The user is active and allowed to log in.
-  USER_STATUS_ACTIVE = 1;
+  USER_STATUS_ACTIVE = 0;
   // The user can log in but its validity is about to expire.
   // The actual grace period the user is granted depends on its tenant's policy.
-  USER_STATUS_EXPIRING = 2;
+  USER_STATUS_EXPIRING = 1;
   // The user is valid but it has been blocked from login in its tenant.
-  USER_STATUS_BLOCKED = 3;
+  USER_STATUS_BLOCKED = 2;
 }
 


### PR DESCRIPTION
Follow up from #261 - eventually turning to a full status field, which defaults to `ACTIVE` (and no INVALID value is defined).