### PR TITLE
Replace favorites with a more generic labels API

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -209,10 +209,10 @@ service GatewayAPI {
   rpc UpdateStorageSpace(cs3.storage.provider.v1beta1.UpdateStorageSpaceRequest) returns (cs3.storage.provider.v1beta1.UpdateStorageSpaceResponse);
   // Deletes a storage space.
   rpc DeleteStorageSpace(cs3.storage.provider.v1beta1.DeleteStorageSpaceRequest) returns (cs3.storage.provider.v1beta1.DeleteStorageSpaceResponse);
-  // Adds a resource as a favorite for a user.
-  rpc AddFavorite(cs3.storage.provider.v1beta1.AddFavoriteRequest) returns (cs3.storage.provider.v1beta1.AddFavoriteResponse);
-  // Removes a resource from favorites for a user.
-  rpc RemoveFavorite(cs3.storage.provider.v1beta1.RemoveFavoriteRequest) returns (cs3.storage.provider.v1beta1.RemoveFavoriteResponse);
+  // Attach a label to a resource for a user.
+  rpc AddLabel(cs3.storage.provider.v1beta1.AddLabelRequest) returns (cs3.storage.provider.v1beta1.AddLabelResponse);
+  // Removes a label from a resource for a user.
+  rpc RemoveLabel(cs3.storage.provider.v1beta1.RemoveLabelRequest) returns (cs3.storage.provider.v1beta1.RemoveLabelResponse);
   // *****************************************************************/
   // ************************ APP PROVIDER ********************/
   // *****************************************************************/

--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -176,10 +176,10 @@ service ProviderAPI {
   rpc CreateHome(CreateHomeRequest) returns (CreateHomeResponse);
   // Gets the home path for the user.
   rpc GetHome(GetHomeRequest) returns (GetHomeResponse);
-  // Marks a resource as favorite for a user.
-  rpc AddFavorite(AddFavoriteRequest) returns (AddFavoriteResponse);
-  // Unmarks a resource as favorite for a user.
-  rpc RemoveFavorite(RemoveFavoriteRequest) returns (RemoveFavoriteResponse);
+  // Attach a label to a resource for a user.
+  rpc AddLabel(AddLabelRequest) returns (AddLabelResponse);
+  // Removes a label from a resource for a user.
+  rpc RemoveLabel(RemoveLabelRequest) returns (RemoveLabelResponse);
 }
 
 message GetHomeRequest {
@@ -1078,7 +1078,7 @@ message CreateHomeResponse {
   cs3.types.v1beta1.Opaque opaque = 2;
 }
 
-message AddFavoriteRequest {
+message AddLabelRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
@@ -1086,11 +1086,14 @@ message AddFavoriteRequest {
   // The reference to which the action should be performed.
   Reference ref = 2;
   // REQUIRED.
-  // The user marking the resource as favorite.
+  // The user attaching the label to the resource.
   cs3.identity.user.v1beta1.UserId user_id = 3;
+  // REQUIRED.
+  // The label to be attached to the resource.
+  string label = 4;
 }
 
-message AddFavoriteResponse {
+message AddLabelResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;
@@ -1099,7 +1102,7 @@ message AddFavoriteResponse {
   cs3.types.v1beta1.Opaque opaque = 2;
 }
 
-message RemoveFavoriteRequest {
+message RemoveLabelRequest {
   // OPTIONAL.
   // Opaque information.
   cs3.types.v1beta1.Opaque opaque = 1;
@@ -1107,11 +1110,14 @@ message RemoveFavoriteRequest {
   // The reference to which the action should be performed.
   Reference ref = 2;
   // REQUIRED.
-  // The user un-marking the resource as favorite.
+  // The user removing the label from the resource.
   cs3.identity.user.v1beta1.UserId user_id = 3;
+  // REQUIRED.
+  // The label to be removed from the resource.
+  string label = 4;
 }
 
-message RemoveFavoriteResponse {
+message RemoveLabelResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;


### PR DESCRIPTION
As a follow-up to https://github.com/cs3org/cs3apis/pull/260.

We would like to have a more generic version of the favorites API, where we can attach arbitrary labels to resources. These lables are user-scoped just like favorites. Migrating from AddFavorite to AddLabel would just be replacing the method name, and adding `Label: "favorite"`. 